### PR TITLE
Call help when app name is not provided

### DIFF
--- a/lib/lotus/cli.rb
+++ b/lib/lotus/cli.rb
@@ -68,7 +68,7 @@ module Lotus
     method_option :help,           aliases: '-h', desc: 'displays the usage method'
 
     def new(name = nil)
-      if options[:help]
+      if options[:help] || name.nil?
         invoke :help, ['new']
       else
         require 'lotus/commands/new'


### PR DESCRIPTION
Call `--help` options instead of returning error code like this:

```
/opt/boxen/rbenv/versions/2.2.0/lib/ruby/2.2.0/pathname.rb:397:in `initialize': no implicit conversion of nil into String (TypeError)
    from /opt/boxen/rbenv/versions/2.2.0/lib/ruby/2.2.0/pathname.rb:397:in `new'
    from /opt/boxen/rbenv/versions/2.2.0/lib/ruby/2.2.0/pathname.rb:397:in `join'
    from /private/tmp/lotus/lib/lotus/commands/new.rb:17:in `initialize'
    from /private/tmp/lotus/lib/lotus/cli.rb:76:in `new'
    from /private/tmp/lotus/lib/lotus/cli.rb:76:in `new'
    from /opt/boxen/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /opt/boxen/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /opt/boxen/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /opt/boxen/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /private/tmp/lotus/bin/lotus:4:in `<top (required)>'
    from /opt/boxen/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/bin/lotus:23:in `load'
    from /opt/boxen/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/bin/lotus:23:in `<main>'
```