### PR TITLE
Enhancement for Lotus App Generator

### DIFF
--- a/lib/lotus/generators/application/container.rb
+++ b/lib/lotus/generators/application/container.rb
@@ -33,6 +33,7 @@ module Lotus
             'config/.env.development.tt' => 'config/.env.development',
             'config/.env.test.tt'        => 'config/.env.test',
             'lib/app_name.rb.tt'         => "lib/#{ app_name }.rb",
+            'lib/config/mapping.rb.tt'   => 'lib/config/mapping.rb',
           }
 
           empty_directories = [

--- a/lib/lotus/generators/application/container/lib/app_name.rb.tt
+++ b/lib/lotus/generators/application/container/lib/app_name.rb.tt
@@ -19,6 +19,9 @@ Lotus::Model.configure do
   ##
   # Database mapping
   #
+  # Optionally, you can specify mapping file to load with:
+  #   mapping "{__dir__}/config/mapping"
+  #
   mapping do
     # collection :users do
     #   entity     User

--- a/lib/lotus/generators/application/container/lib/app_name.rb.tt
+++ b/lib/lotus/generators/application/container/lib/app_name.rb.tt
@@ -1,5 +1,5 @@
 require 'lotus/model'
-Dir["#{ __dir__ }/**/*.rb"].each { |file| require_relative file }
+Dir["#{ __dir__ }/<%= config[:app_name] %>/**/*.rb"].each { |file| require_relative file }
 
 Lotus::Model.configure do
   # Database adapter

--- a/lib/lotus/generators/application/container/lib/app_name.rb.tt
+++ b/lib/lotus/generators/application/container/lib/app_name.rb.tt
@@ -19,8 +19,11 @@ Lotus::Model.configure do
   ##
   # Database mapping
   #
-  # Optionally, you can specify mapping file to load with:
-  #   mapping "{__dir__}/config/mapping"
+  # You can specify mapping file to load with:
+  #
+  # mapping "{__dir__}/config/mapping"
+  #
+  # Alternatively, you can use a block syntax like the following:
   #
   mapping do
     # collection :users do

--- a/lib/lotus/generators/application/container/lib/config/mapping.rb.tt
+++ b/lib/lotus/generators/application/container/lib/config/mapping.rb.tt
@@ -1,0 +1,7 @@
+# collection :users do
+#   entity     User
+#   repository UserRepository
+#
+#   attribute :id,   Integer
+#   attribute :name, String
+# end

--- a/lib/lotus/generators/slice/templates/application.html.erb
+++ b/lib/lotus/generators/slice/templates/application.html.erb
@@ -1,9 +1,0 @@
-<!doctype HTML>
-<html>
-  <head>
-    <title>Chirp!</title>
-  </head>
-  <body>
-    <%= yield %>
-  </body>
-</html>

--- a/test/commands/new_test.rb
+++ b/test/commands/new_test.rb
@@ -167,6 +167,19 @@ describe Lotus::Commands::New do
         content.must_match %(Lotus::Model.configure)
         content.must_match %(adapter type: :file_system, uri: ENV['CHIRP_DATABASE_URL'])
         content.must_match %(mapping do)
+        content.must_match %(mapping "{__dir__}/config/mapping")
+      end
+    end
+
+    describe 'lib/config/mapping.rb' do
+      it 'generates it' do
+        content = @root.join('lib/config/mapping.rb').read
+        content.must_match %(collection :users do)
+        content.must_match %(entity     User)
+        content.must_match %(repository UserRepository)
+        content.must_match %(attribute :id,   Integer)
+        content.must_match %(attribute :name, String)
+        content.must_match %(end)
       end
     end
 

--- a/test/commands/new_test.rb
+++ b/test/commands/new_test.rb
@@ -162,7 +162,7 @@ describe Lotus::Commands::New do
     describe 'lib/chirp.rb' do
       it 'generates it' do
         content = @root.join('lib/chirp.rb').read
-        content.must_match 'Dir["#{ __dir__ }/**/*.rb"].each { |file| require_relative file }'
+        content.must_match 'Dir["#{ __dir__ }/chirp/**/*.rb"].each { |file| require_relative file }'
         content.must_match %(require 'lotus/model')
         content.must_match %(Lotus::Model.configure)
         content.must_match %(adapter type: :file_system, uri: ENV['CHIRP_DATABASE_URL'])

--- a/test/commands/new_test.rb
+++ b/test/commands/new_test.rb
@@ -174,12 +174,12 @@ describe Lotus::Commands::New do
     describe 'lib/config/mapping.rb' do
       it 'generates it' do
         content = @root.join('lib/config/mapping.rb').read
-        content.must_match %(collection :users do)
-        content.must_match %(entity     User)
-        content.must_match %(repository UserRepository)
-        content.must_match %(attribute :id,   Integer)
-        content.must_match %(attribute :name, String)
-        content.must_match %(end)
+        content.must_match %(# collection :users do)
+        content.must_match %(#   entity     User)
+        content.must_match %(#   repository UserRepository)
+        content.must_match %(#   attribute :id,   Integer)
+        content.must_match %(#   attribute :name, String)
+        content.must_match %(# end)
       end
     end
 


### PR DESCRIPTION
What:
Currently, we eager-loading _all_ files in `/lib`, which is not very ideal in the scenario that users want to place some lazy-loading files in this folder, such as the mapping file. So after discussion with @jodosha, it is decided that we:

* [X] Eager-load only  `lib/chirp/**/*`
* [X] Provide an option to load mapping from file, and it will be located at `lib/config/mapping.rb`

Much thanks to @tranvictor for bug report