### PR TITLE
Removed support for MRI ruby versions lower than 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,6 @@ sudo: false
 cache: bundler
 script: 'bundle exec rake test:coverage'
 rvm:
-  - 2.0.0
-  - 2.1.0
-  - 2.1.1
-  - 2.1.2
-  - 2.1.3
-  - 2.1.4
-  - 2.1.5
   - 2.2.0
   - rbx-2
   - jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 if !ENV['TRAVIS']
-  gem 'byebug', require: false, platforms: :mri if RUBY_VERSION >= '2.1.0'
+  gem 'byebug', require: false, platforms: :mri
   gem 'yard',   require: false
 end
 

--- a/lotusrb.gemspec
+++ b/lotusrb.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_dependency 'lotus-utils',      '~> 0.3', '>= 0.3.4'
   spec.add_dependency 'lotus-router',     '~> 0.2', '>= 0.2.1'


### PR DESCRIPTION
Rationale: https://discuss.lotusrb.org/t/supported-ruby-vms/28