### PR TITLE
Dynamic finders for application routes

### DIFF
--- a/lib/lotus/routes.rb
+++ b/lib/lotus/routes.rb
@@ -31,7 +31,7 @@ module Lotus
     #
     # @see http://rdoc.info/gems/lotus-router/Lotus/Router#path-instance_method
     #
-    # @example
+    # @example Basic example
     #   require 'lotus'
     #
     #   module Bookshelf
@@ -48,6 +48,25 @@ module Lotus
     #     # => '/login'
     #
     #   Bookshelf::Routes.path(:login, return_to: '/dashboard')
+    #     # => '/login?return_to=%2Fdashboard'
+    #
+    # @example Dynamic finders
+    #   require 'lotus'
+    #
+    #   module Bookshelf
+    #     class Application < Lotus::Application
+    #       configure do
+    #         routes do
+    #           get '/login', to: 'sessions#new', as: :login
+    #         end
+    #       end
+    #     end
+    #   end
+    #
+    #   Bookshelf::Routes.login_path
+    #     # => '/login'
+    #
+    #   Bookshelf::Routes.login_path(return_to: '/dashboard')
     #     # => '/login?return_to=%2Fdashboard'
     def path(name, *args)
       @routes.path(name, *args)
@@ -67,7 +86,7 @@ module Lotus
     #
     # @see http://rdoc.info/gems/lotus-router/Lotus/Router#url-instance_method
     #
-    # @example
+    # @example Basic example
     #   require 'lotus'
     #
     #   module Bookshelf
@@ -88,8 +107,43 @@ module Lotus
     #
     #   Bookshelf::Routes.url(:login, return_to: '/dashboard')
     #     # => 'https://bookshelf.org/login?return_to=%2Fdashboard'
+    #
+    # @example Dynamic finders
+    #   require 'lotus'
+    #
+    #   module Bookshelf
+    #     class Application < Lotus::Application
+    #       configure do
+    #         routes do
+    #           scheme 'https'
+    #           host   'bookshelf.org'
+    #
+    #           get '/login', to: 'sessions#new', as: :login
+    #         end
+    #       end
+    #     end
+    #   end
+    #
+    #   Bookshelf::Routes.login_url
+    #     # => 'https://bookshelf.org/login'
+    #
+    #   Bookshelf::Routes.login_url(return_to: '/dashboard')
+    #     # => 'https://bookshelf.org/login?return_to=%2Fdashboard'
     def url(name, *args)
       @routes.url(name, *args)
+    end
+
+    protected
+    # @since x.x.x
+    # @api private
+    def method_missing(m, *args)
+      named_route, type = m.to_s.split(/\_(path|url)\z/)
+
+      if type
+        public_send(type, named_route.to_sym, *args)
+      else
+        super
+      end
     end
   end
 end

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -31,4 +31,30 @@ describe Lotus::Routes do
       -> { @routes.url(:unknown) }.must_raise Lotus::Routing::InvalidRouteException
     end
   end
+
+  describe 'dynamic finders' do
+    describe 'for relative URLs' do
+      it 'recognizes named route' do
+        @routes.root_path.must_equal '/'
+      end
+
+      it "raises an error if an unknown path is invoked" do
+        -> { @routes.unknown_path }.must_raise Lotus::Routing::InvalidRouteException
+      end
+    end
+
+    describe 'for absolute URLs' do
+      it 'recognizes named route' do
+        @routes.root_url.must_equal "#{ @scheme }://#{ @host }/"
+      end
+
+      it "raises an error if an unknown url is invoked" do
+        -> { @routes.unknown_url }.must_raise Lotus::Routing::InvalidRouteException
+      end
+    end
+
+    it 'raises an error for unknown methods' do
+      -> { @routes.foo }.must_raise NoMethodError
+    end
+  end
 end


### PR DESCRIPTION
### Now

For a given `Web::Application`, at the runtime Lotus generates a factory for its routes: `Web::Routes`.
Until now it used to respond to two methods: `#path` and `#url` for relative and absolute URLs, respectively.

```ruby
Web::Routes.path(:books) # => "/books"
Web::Routes.url(:books) # => "https://bookshelf.org/books"

Web::Routes.path(:books, title: 'TDD') # => "/books?title=TDD"
Web::Routes.path(:book, id: 23) # => "/books/23"
```

### What

This PR introduces dynamic finders for routes factory:

```ruby
Web::Routes.books_path # => "/books"
Web::Routes.books_url # => "https://bookshelf.org/books"

Web::Routes.books_path(title: 'TDD') # => "/books?title=TDD"
Web::Routes.book_path(id: 23) # => "/books/23"
```

### Why

This serves as a base to for **routing helpers**. Their usage will be:

```erb
<%= routes.book_path(id: 23) %>
```

Ref https://github.com/lotus/helpers/pull/14