### PR TITLE
Change SQLite file extension to .sqlite3

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ module Bookshelf
       #           uri:  String, 'file:///db/bookshelf'
       #                         'memory://localhost/bookshelf'
       #                         'sqlite:memory:'
-      #                         'sqlite://db/bookshelf.db'
+      #                         'sqlite://db/bookshelf.sqlite3'
       #                         'postgres://localhost/bookshelf'
       #                         'mysql://localhost/bookshelf'
       #

--- a/lib/lotus/generators/application/container/lib/app_name.rb.tt
+++ b/lib/lotus/generators/application/container/lib/app_name.rb.tt
@@ -10,7 +10,7 @@ Lotus::Model.configure do
   #    adapter type: :memory, uri: 'memory://localhost/<%= config[:app_name] %>_development'
   #
   #  * SQL adapter
-  #    adapter type: :sql, uri: 'sqlite://db/<%= config[:app_name] %>_development.db'
+  #    adapter type: :sql, uri: 'sqlite://db/<%= config[:app_name] %>_development.sqlite3'
   #    adapter type: :sql, uri: 'postgres://localhost/<%= config[:app_name] %>_development'
   #    adapter type: :sql, uri: 'mysql://localhost/<%= config[:app_name] %>_development'
   #

--- a/lib/lotus/generators/slice/application.rb.tt
+++ b/lib/lotus/generators/slice/application.rb.tt
@@ -87,7 +87,7 @@ module <%= config[:classified_slice_name] %>
       #           uri:  String, 'file:///db/bookshelf'
       #                         'memory://localhost/bookshelf'
       #                         'sqlite:memory:'
-      #                         'sqlite://db/bookshelf.db'
+      #                         'sqlite://db/bookshelf.sqlite3'
       #                         'postgres://localhost/bookshelf'
       #                         'mysql://localhost/bookshelf'
       #

--- a/test/fixtures/collaboration/apps/web/application.rb
+++ b/test/fixtures/collaboration/apps/web/application.rb
@@ -11,7 +11,7 @@ ADAPTER_TYPE =  if RUBY_ENGINE == 'jruby'
                 end
 
 require 'lotus/model/adapters/sql_adapter'
-db = Pathname.new(File.dirname(__FILE__)).join('../tmp/test.db')
+db = Pathname.new(File.dirname(__FILE__)).join('../tmp/test.sqlite3')
 db.dirname.mkpath      # create directory if not exist
 db.delete if db.exist? # delete file if exist
 SQLITE_CONNECTION_STRING = "#{ADAPTER_TYPE}://#{ db }"


### PR DESCRIPTION
As a user of Sublime Text, Switching to the :sql adaptor with sqlite
generates a `<app_name>_development.db` file. Sublime text by default
hides .db extension, and having the original directories generated by
the :file_system adaptor lying around added a little bit of confusion
as to why I couldn't see a database file, even though I could access it
within the REPL.

Although the adaptor is specified within the codebase, the database
file is probably more likely to be stored in another location outwith
the repository when deployed to a server. Having a more useful extension
might be helpful. Thoughts?