### PR TITLE
Added support for lotusrc in Lotus::Environment

### DIFF
--- a/.lotusrc
+++ b/.lotusrc
@@ -1,0 +1,3 @@
+architecture=container
+test=minitest
+template=erb

--- a/lib/lotus/environment.rb
+++ b/lib/lotus/environment.rb
@@ -2,6 +2,7 @@ require 'thread'
 require 'pathname'
 require 'dotenv'
 require 'lotus/utils/hash'
+require 'lotus/lotusrc'
 
 module Lotus
   # Define and expose information about the Lotus environment.
@@ -156,6 +157,7 @@ module Lotus
     #   # other settings (eg `XYZ`) will be left untouched.
     def initialize(options = {})
       @options = Utils::Hash.new(options).symbolize!.freeze
+      @options.merge! Lotus::Lotusrc.new(root, self.to_options).read
       @mutex   = Mutex.new
       @mutex.synchronize { set_env_vars! }
     end

--- a/lib/lotus/lotusrc.rb
+++ b/lib/lotus/lotusrc.rb
@@ -1,0 +1,143 @@
+require 'pathname'
+require 'dotenv'
+
+module Lotus
+  # Create and read the .lotusrc file in the root of the application
+  #
+  # @since x.x.x
+  # @api private
+  class Lotusrc
+    # Lotusrc name file
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see Lotus::Lotusrc#path_file
+    FILE_NAME = '.lotusrc'.freeze
+
+    # Architecture default value
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see Lotus::Lotusrc#read
+    DEFAULT_ARCHITECTURE = 'container'.freeze
+
+    # Architecture key for writing the lotusrc file
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see Lotus::Lotusrc#read
+    ARCHITECTURE_KEY = 'architecture'.freeze
+
+    # Test suite default value
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see Lotus::Lotusrc#read
+    DEFAULT_TEST_SUITE = 'minitest'.freeze
+
+    # Test suite key for writing the lotusrc file
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see Lotus::Lotusrc#read
+    TEST_KEY = 'test'.freeze
+
+    # Template default value
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see Lotus::Lotusrc#read
+    DEFAULT_TEMPLATE = 'erb'.freeze
+
+    # Template key for writing the lotusrc file
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see Lotus::Lotusrc#read
+    TEMPLATE_KEY = 'template'.freeze
+
+    # Initialize Lotusrc class with application's root and enviroment options.
+    # Create the lotusrc file if it doesn't exist in the root given.
+    #
+    # @param [Pathname] Application's root
+    # @param [Hash] Environment's options
+    #
+    # @see Lotus::Environment#initialize
+    def initialize(root, options = {})
+      @root    = root
+      @options = options
+      create
+    end
+
+    # Read lotusrc file and parse it's values.
+    #
+    # @return [Lotus::Utils::Hash] parsed values
+    #
+    # @example Default values if file doesn't exist
+    #   Lotus::Lotusrc.new(Pathname.new(Dir.pwd)).read
+    #    # => { architecture: 'container', test: 'minitest', template: 'erb' }
+    #
+    # @example Custom values if file doesn't exist
+    #   options = { architect: 'application', test: 'rspec', template: 'slim' }
+    #   Lotus::Lotusrc.new(Pathname.new(Dir.pwd), options).read
+    #    # => { architecture: 'application', test: 'rspec', template: 'slim' }
+    def read
+      if exists?
+        lotusrc_options = Dotenv.load path_file
+        Utils::Hash.new(lotusrc_options).symbolize!
+      end
+    end
+
+    private
+
+    # Create lotusrc file if exists
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see Lotus::Lotusrc::DEFAULT_ARCHITECTURE
+    # @see Lotus::Lotusrc::ARCHITECTURE_KEY
+    # @see Lotus::Lotusrc::DEFAULT_TEST_SUITE
+    # @see Lotus::Lotusrc::TEST_KEY
+    # @see Lotus::Lotusrc::DEFAULT_TEMPLATE
+    # @see Lotus::Lotusrc::TEMPLATE_KEY
+    def create
+      unless exists?
+        rcfile = File.new(path_file, "w")
+        rcfile.puts "#{ ARCHITECTURE_KEY }=#{ @options.fetch(:architecture, DEFAULT_ARCHITECTURE) }"
+        rcfile.puts "#{ TEST_KEY }=#{ @options.fetch(:test, DEFAULT_TEST_SUITE) }"
+        rcfile.puts "#{ TEMPLATE_KEY }=#{ @options.fetch(:template, DEFAULT_TEMPLATE) }"
+        rcfile.close
+      end
+    end
+
+    # Check if lotusrc file exists
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @return [Boolean] lotusrc file's path existing
+    def exists?
+      path_file.exist?
+    end
+
+    # Return the lotusrc file's path
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @return [Pathname] lotusrc file's path
+    #
+    # @see Lotus::Lotusrc::FILE_NAME
+    def path_file
+      @root.join FILE_NAME
+    end
+  end
+end

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -433,4 +433,23 @@ describe Lotus::Environment do
       end
     end
   end
+
+  describe '#to_options' do
+    before do
+      @old_pwd = Dir.pwd
+      Dir.chdir 'test/fixtures/lotusrc/exists'
+      @env = Lotus::Environment.new
+    end
+
+    after do
+      Dir.chdir @old_pwd
+    end
+
+    it 'lotusrc merge options in environemnt options' do
+      options = @env.to_options
+      options[:architecture].must_equal 'container'
+      options[:test].must_equal 'minitest'
+      options[:template].must_equal 'erb'
+    end
+  end
 end

--- a/test/fixtures/lotusrc/exists/.lotusrc
+++ b/test/fixtures/lotusrc/exists/.lotusrc
@@ -1,0 +1,3 @@
+architecture=container
+test=minitest
+template=erb

--- a/test/fixtures/microservices/.lotusrc
+++ b/test/fixtures/microservices/.lotusrc
@@ -1,0 +1,3 @@
+architecture=container
+test=minitest
+template=erb

--- a/test/lotusrc_test.rb
+++ b/test/lotusrc_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+
+describe Lotus::Lotusrc do
+  describe '#read' do
+    describe 'file exists' do
+      before do
+        @old_pwd = Dir.pwd
+        Dir.chdir 'test/fixtures/lotusrc/exists'
+        @root = Pathname.new(Dir.pwd)
+        @lotusrc = Lotus::Lotusrc.new(@root)
+      end
+
+      after do
+        Dir.chdir @old_pwd
+      end
+
+      it 'get values in the file' do
+        options = @lotusrc.read
+        options[:architecture].must_equal 'container'
+        options[:test].must_equal 'minitest'
+        options[:template].must_equal 'erb'
+      end
+
+      it 'get values although arguments are passed' do
+        options = { architecture: 'application', test: 'rspec', template: 'slim' }
+        lotusrc = Lotus::Lotusrc.new(@root, options)
+        options = lotusrc.read
+        options[:architecture].must_equal 'container'
+        options[:test].must_equal 'minitest'
+        options[:template].must_equal 'erb'
+      end
+    end
+
+    describe "file doesn't exist" do
+      before do
+        @old_pwd = Dir.pwd
+        Dir.chdir 'test/fixtures/lotusrc/no_exists'
+        @root = Pathname.new(Dir.pwd)
+      end
+
+      after do
+        Dir.chdir @old_pwd
+      end
+
+      describe 'default values' do
+        before do
+          @file = Pathname.new(Dir.pwd).join('.lotusrc')
+          @lotusrc = Lotus::Lotusrc.new(@root)
+        end
+
+        after do
+          File.delete(@file)
+        end
+
+        it 'read the file' do
+          options = @lotusrc.read
+          options[:architecture].must_equal 'container'
+          options[:test].must_equal 'minitest'
+          options[:template].must_equal 'erb'
+        end
+      end
+
+      describe 'custom values' do
+        before do
+          @file = Pathname.new(Dir.pwd).join('.lotusrc')
+          options = { architecture: 'application', test: 'rspec', template: 'slim' }
+          @lotusrc = Lotus::Lotusrc.new(@root, options)
+        end
+
+        after do
+          File.delete(@file)
+        end
+
+        it 'read the file' do
+          options = @lotusrc.read
+          options[:architecture].must_equal 'application'
+          options[:test].must_equal 'rspec'
+          options[:template].must_equal 'slim'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #156 

`.lotusrc` is created in the application root if it doesn't exist when `Lotus::Environment` is instantiated.

`architecture`, `test` and `template` are added in the `.lotusrc` file.

FYI: several `.lotusrc` are created by tests.