### PR TITLE
Init a git repo when generating a new application with container arch

### DIFF
--- a/lib/lotus/generators/application/container.rb
+++ b/lib/lotus/generators/application/container.rb
@@ -1,3 +1,4 @@
+require 'shellwords'
 require 'lotus/generators/abstract'
 require 'lotus/generators/slice'
 
@@ -74,7 +75,18 @@ module Lotus
             cli.template(source.join(gitkeep), target.join(dir, gitkeep), opts)
           end
 
+          unless git_dir_present?
+            cli.template(source.join('gitignore.tt'), target.join('.gitignore'), opts)
+            cli.run("git init #{Shellwords.escape(target)}", capture: true)
+          end
+
           @slice_generator.start
+        end
+
+        private
+
+        def git_dir_present?
+          File.directory?(source.join('.git'))
         end
       end
     end

--- a/lib/lotus/generators/application/container/gitignore.tt
+++ b/lib/lotus/generators/application/container/gitignore.tt
@@ -1,0 +1,2 @@
+/db/<%= config[:app_name] %>_development
+/db/<%= config[:app_name] %>_test

--- a/test/commands/new_test.rb
+++ b/test/commands/new_test.rb
@@ -124,6 +124,14 @@ describe Lotus::Commands::New do
       end
     end
 
+    describe '.gitignore' do
+      it 'generates it' do
+        content = @root.join('.gitignore').read
+        content.must_match %(/db/chirp_development)
+        content.must_match %(/db/chirp_test)
+      end
+    end
+
     describe 'config/environment.rb' do
       it 'generates it' do
         content = @root.join('config/environment.rb').read


### PR DESCRIPTION
I read this issue https://github.com/lotus/lotus/issues/132 and thought I'd whip something simple together. Perhaps someone else has already implemented it.

What do you think about this? I guess we should check if the `git` command is available before trying to run it?

Is there a better way to run a command inside the root dir than this?
```ruby
cli.run("git init #{Shellwords.escape(target)}", capture: true)
```

Closes #132 