### PR TITLE
Set relative template path in generated apps' config

### DIFF
--- a/lib/lotus/generators/slice/application.rb.tt
+++ b/lib/lotus/generators/slice/application.rb.tt
@@ -108,7 +108,7 @@ module <%= config[:classified_slice_name] %>
 
       # The relative path to templates
       #
-      # templates 'templates'
+      templates 'templates'
 
       ##
       # ASSETS

--- a/test/commands/new_test.rb
+++ b/test/commands/new_test.rb
@@ -592,7 +592,7 @@ describe Lotus::Commands::New do
         content.must_match %(# mapping 'config/mapping')
 
         content.must_match %(layout :application)
-        content.must_match %(# templates 'templates')
+        content.must_match %(templates 'templates')
 
         content.must_match %(# cookies true)
 


### PR DESCRIPTION
I am suggesting to comment in the templates path in new apps.

I had the following problem (which might still be another issue):
- Lotus by default also looks for templates in `public/**`
- I had a `public/stylesheets/application.css.map` file
- Because it has two file extensions,  Lotus thinks, it has to parse it as a template
- `RuntimeError: No template engine registered for application.css.map` :zap: 

Won't happen if I the relative template path is set.