### PR TITLE
Preload application in config/environment file.

### DIFF
--- a/lib/lotus/generators/application/container.rb
+++ b/lib/lotus/generators/application/container.rb
@@ -37,6 +37,7 @@ module Lotus
             'Gemfile.tt'               => 'Gemfile',
             'config.ru.tt'             => 'config.ru',
             'config/environment.rb.tt' => 'config/environment.rb',
+            'config/loader.rb.tt'      => 'config/loader.rb',
             'lib/app_name.rb.tt'       => "lib/#{ app_name }.rb",
             'lib/config/mapping.rb.tt' => 'lib/config/mapping.rb',
           }

--- a/lib/lotus/generators/application/container/config/loader.rb.tt
+++ b/lib/lotus/generators/application/container/config/loader.rb.tt
@@ -1,0 +1,3 @@
+require_relative './environment'
+
+Lotus::Application.preload_applications!

--- a/test/commands/new_test.rb
+++ b/test/commands/new_test.rb
@@ -219,6 +219,14 @@ describe Lotus::Commands::New do
       end
     end
 
+    describe 'config/loader.rb' do
+      it 'generates it' do
+        content = @root.join('config/loader.rb').read
+        content.must_match %(require_relative './environment')
+        content.must_match %(Lotus::Application.preload_applications!)
+      end
+    end
+
     describe '.env' do
       it 'generates it' do
         content = @root.join('.env').read
@@ -659,6 +667,14 @@ describe Lotus::Commands::New do
       end
     end
 
+    describe 'config/loader.rb' do
+      it 'generates it' do
+        content = @root.join('config/loader.rb').read
+        content.must_match %(require_relative './environment')
+        content.must_match %(Lotus::Application.preload_applications!)
+      end
+    end
+
     describe '.env.development' do
       it 'patches the file to reference slice env vars' do
         content = @root.join('.env.development').read
@@ -833,6 +849,14 @@ describe Lotus::Commands::New do
         it 'generates it' do
           content = @root.join('config/environment.rb').read
           content.must_match %(require_relative '../lib/new')
+        end
+      end
+
+      describe 'config/loader.rb' do
+        it 'generates it' do
+          content = @root.join('config/loader.rb').read
+          content.must_match %(require_relative './environment')
+          content.must_match %(Lotus::Application.preload_applications!)
         end
       end
 


### PR DESCRIPTION
Hi there,

I had an issue with the `load_paths` and rake tasks / sidekiq workers.

## Links
The background and problem is based on the following code: https://gist.github.com/smt116/db97a1929162f643e073

## Background
Basically I have `services` and `workers` directories in the `apps/streamer`:
```
apps
├── metrics
[...]
└── streamer
    ├── application.rb
    ├── services
    │   └── foo.rb
    ├── tasks
    │   └── streamer.rake
    └── workers
        └── bar.rb
```
I have also `rake streamer:start` rake task which invokes `Streamer::Services::Foo.perform` action. This action streams messages from external, public API. After fetching each message, service passes it to the sidekiq worker which performs some actions on it and saves object into the database (slow `file_system` for test purposes). I have to use worker, because public API won't "wait" for my processing and it have to be as fast as it can.

## Problem
My problem is that `rake streamer:start` **and** `bundle exec sidekiq -C config/sidekiq.yml -r./config/environment.rb` will result in `NameError: uninitialized constant Streamer::Services` exception. I can solve it by adding explicit requires to `config/environment.rb`:
```
require_relative '../apps/streamer/workers/bar'
require_relative '../apps/streamer/services/foo'
```
but the same should be done by `load_paths` from `apps/streamer/application.rb`. I don't want to specify the same thing in two different places each time ;)

## Solution
The solution is to preload application in the `config/environment.rb` file so it will load proper files. I am playing with Lotus framework for 2 days now (and already love it :star2:) so not sure if it won't break something up.

Btw. sidekiq works out-of-the-box:
```
# apps/streamer/workers/foo.rb
require "sidekiq"

module Streamer::Workers
  class Foo
    include Sidekiq::Worker

    def perform(bar)
      ...
    end
  end
end

# apps/streamer/application.rb
module Streamer
  class Application < Lotus::Application
    configure do
      root __dir__

      load_paths << [
        'workers',
        'services'
      ]

      handle_exceptions false
    end
  end
end

# bundle exec sidekiq -C config/sidekiq.yml -r./config/environment.rb
```