### PR TITLE
Add --skip-view flag to lotus generate action

### DIFF
--- a/lib/lotus/cli.rb
+++ b/lib/lotus/cli.rb
@@ -80,13 +80,14 @@ module Lotus
     end
 
     desc 'generate', 'generates a new action'
-    method_option :path,                desc: 'applications path',        type: :string, default: 'apps'
+    method_option :path,                desc: 'applications path',                                         type: :string,  default: 'apps'
+    method_option :skip_view,           desc: 'skip the creation of view and templates (only for action)', type: :boolean, default: false
     method_option :help, aliases: '-h', desc: 'displays the usage method'
 
     # @since 0.3.0
     # @api private
     def generate(type = nil, app_name = nil, name = nil)
-      if options[:help] || (type.nil? && app_name.nil? && name.nil?)
+      if options[:help] || (type.nil? && app_name.nil? && name.nil?) || (options[:skip_view] && type != 'action')
         invoke :help, ['generate']
       else
         require 'lotus/commands/generate'

--- a/lib/lotus/cli.rb
+++ b/lib/lotus/cli.rb
@@ -87,7 +87,7 @@ module Lotus
     # @since 0.3.0
     # @api private
     def generate(type = nil, app_name = nil, name = nil)
-      if options[:help] || (type.nil? && app_name.nil? && name.nil?) || (options[:skip_view] && type != 'action')
+      if options[:help] || (type.nil? && app_name.nil? && name.nil?)
         invoke :help, ['generate']
       else
         require 'lotus/commands/generate'

--- a/lib/lotus/generators/action.rb
+++ b/lib/lotus/generators/action.rb
@@ -48,22 +48,23 @@ module Lotus
           template_path: _template_path,
         }
 
-        templates = {
-          'action.rb.tt' => _action_path,
-          'view.rb.tt'   => _view_path,
-          'template.tt'  => _template_path
-        }
-
         case options[:test]
         when 'rspec'
-          templates.merge!({
-            'action_spec.rspec.tt' => _action_spec_path,
-            'view_spec.rspec.tt'   => _view_spec_path,
-          })
+          test_type = 'rspec'
         else
+          test_type = 'minitest'
+        end
+
+        templates = {
+          'action.rb.tt' => _action_path,
+          'action_spec.' + test_type + '.tt' => _action_spec_path,
+        }
+
+        if !options[:skip_view]
           templates.merge!({
-            'action_spec.minitest.tt' => _action_spec_path,
-            'view_spec.minitest.tt'   => _view_spec_path,
+            'view.rb.tt'   => _view_path,
+            'template.tt'  => _template_path,
+            'view_spec.' + test_type + '.tt' => _view_spec_path,
           })
         end
 

--- a/lib/lotus/generators/action.rb
+++ b/lib/lotus/generators/action.rb
@@ -49,11 +49,11 @@ module Lotus
         }
 
         test_type = case options[:test]
-        when 'rspec'
-          'rspec'
-        else
-          'minitest'
-        end
+                    when 'rspec'
+                      'rspec'
+                    else
+                      'minitest'
+                    end
 
         templates = {
           'action.rb.tt' => _action_path,

--- a/lib/lotus/generators/action.rb
+++ b/lib/lotus/generators/action.rb
@@ -48,23 +48,23 @@ module Lotus
           template_path: _template_path,
         }
 
-        case options[:test]
+        test_type = case options[:test]
         when 'rspec'
-          test_type = 'rspec'
+          'rspec'
         else
-          test_type = 'minitest'
+          'minitest'
         end
 
         templates = {
           'action.rb.tt' => _action_path,
-          'action_spec.' + test_type + '.tt' => _action_spec_path,
+          "action_spec.#{test_type}.tt" => _action_spec_path,
         }
 
         if !options[:skip_view]
           templates.merge!({
             'view.rb.tt'   => _view_path,
             'template.tt'  => _template_path,
-            'view_spec.' + test_type + '.tt' => _view_spec_path,
+            "view_spec.#{test_type}.tt" => _view_spec_path,
           })
         end
 

--- a/test/commands/generate_test.rb
+++ b/test/commands/generate_test.rb
@@ -145,6 +145,28 @@ describe Lotus::Commands::Generate do
       end
     end
 
+    describe 'with --skip-view flag' do
+      let(:opts) { default_options.merge(skip_view: true) }
+
+      describe 'apps/web/views/dashboard/index.rb' do
+        it 'does not generate it' do
+          @root.join('apps/web/views/dashboard/index.rb').exist?.must_be_same_as false
+        end
+      end
+
+      describe 'apps/web/templates/dashboard/index.html.erb' do
+        it 'does not generate it' do
+          @root.join('apps/web/views/dashboard/index.rb').exist?.must_be_same_as false
+        end
+      end
+
+      describe 'spec/web/views/dashboard/index_spec.rb' do
+        it 'does not generate it' do
+          @root.join('spec/web/views/dashboard/index_spec.rb').exist?.must_be_same_as false
+        end
+      end
+    end
+
     describe 'with unknown app' do
       before do
         # force not-existing app

--- a/test/integration/cli/generate_test.rb
+++ b/test/integration/cli/generate_test.rb
@@ -33,6 +33,10 @@ template=#{ template_engine }
       `bundle exec lotus generate action #{ app_name } dashboard#index`
     end
 
+    def generate_action_without_view
+      `bundle exec lotus generate action #{ app_name } dashboard#foo --skip-view`
+    end
+
     def generate_model
       `bundle exec lotus generate model #{ klass }`
     end
@@ -45,6 +49,7 @@ template=#{ template_engine }
       create_temporary_dir
       generate_application
       generate_action
+      generate_action_without_view
       generate_model
     end
 
@@ -65,6 +70,14 @@ template=#{ template_engine }
       @root.join('apps/web/templates/dashboard/index.html.erb').must_be  :exist?
       @root.join('spec/web/controllers/dashboard/index_spec.rb').must_be :exist?
       @root.join('spec/web/views/dashboard/index_spec.rb').must_be       :exist?
+    end
+
+    it 'generates an action without view' do
+      @root.join('apps/web/controllers/dashboard/foo.rb').must_be      :exist?
+      @root.join('apps/web/views/dashboard/foo.rb').wont_be            :exist?
+      @root.join('apps/web/templates/dashboard/foo.html.erb').wont_be  :exist?
+      @root.join('spec/web/controllers/dashboard/foo_spec.rb').must_be :exist?
+      @root.join('spec/web/views/dashboard/foo_spec.rb').wont_be       :exist?
     end
 
     describe 'when application is generated with minitest' do


### PR DESCRIPTION
Adding ```--skip-view``` flag when generating a new action prevents the view and the template (and the view spec) from being generated too. This can be useful when developing a JSON api that uses no views or templates.

Example usage:
```bundle exec lotus generate action api users#get --skip-view```

Implements the feature requested in #201 