### PR TITLE
Added routing helpers to actions

### DIFF
--- a/lib/lotus/action/routing_helpers.rb
+++ b/lib/lotus/action/routing_helpers.rb
@@ -1,0 +1,40 @@
+require 'lotus/utils/string'
+
+module Lotus
+  module Action
+    # Routing helper for full stack Lotus web applications.
+    #
+    # For a given application called <tt>Web::Application</tt>, at runtime
+    # Lotus creates a routes factory called <tt>Web::Routes</tt>.
+    #
+    # Included by default in every controller.
+    #
+    # @since x.x.x
+    #
+    # @example Usage in controller
+    #   require 'lotus'
+    #
+    #   module Web::Controllers::Protected
+    #     class Index
+    #       include Web::Action
+    #
+    #       def call(params)
+    #         redirect_to routes.root_path
+    #       end
+    #     end
+    #   end
+    module RoutingHelpers
+      def self.included(base)
+        factory = "#{ Utils::String.new(base).namespace }::Routes"
+
+        base.class_eval <<-END_EVAL, __FILE__, __LINE__
+          private
+
+          def routes
+            #{ factory }
+          end
+        END_EVAL
+      end
+    end
+  end
+end

--- a/lib/lotus/loader.rb
+++ b/lib/lotus/loader.rb
@@ -6,6 +6,7 @@ require 'lotus/routing/default'
 require 'lotus/action/cookies'
 require 'lotus/action/session'
 require 'lotus/config/security'
+require 'lotus/action/routing_helpers'
 
 module Lotus
   # Load an application
@@ -60,6 +61,7 @@ module Lotus
             cookies config.cookies.default_options
           end
           prepare { include Lotus::Action::Session } if config.sessions.enabled?
+          prepare { include Lotus::Action::RoutingHelpers }
 
           config.controller.__apply(self)
         end

--- a/test/fixtures/collaboration/apps/web/app/controllers/books.rb
+++ b/test/fixtures/collaboration/apps/web/app/controllers/books.rb
@@ -44,7 +44,7 @@ module Collaboration::Controllers::Books
       @book = BookRepository.find(params[:id])
       BookRepository.delete(@book)
 
-      redirect_to Collaboration::Routes.url(:books)
+      redirect_to routes.url(:books)
     end
   end
 
@@ -55,7 +55,7 @@ module Collaboration::Controllers::Books
       @book = Book.new(params)
       @book = BookRepository.create(@book)
 
-      redirect_to Collaboration::Routes.url(:book, id: @book.id)
+      redirect_to routes.url(:book, :id => @book.id)
     end
   end
 
@@ -67,7 +67,7 @@ module Collaboration::Controllers::Books
       @book.update(params)
       @book = BookRepository.update(@book)
 
-      redirect_to Collaboration::Routes.url(:book, id: @book.id)
+      redirect_to routes.url(:book, :id => @book.id)
     end
   end
 end

--- a/test/fixtures/collaboration/apps/web/app/controllers/home.rb
+++ b/test/fixtures/collaboration/apps/web/app/controllers/home.rb
@@ -18,7 +18,7 @@ module Collaboration::Controllers::Home
     include Collaboration::Action
 
     def call(params)
-      redirect_to Collaboration::Routes.url(:root)
+      redirect_to routes.url(:root)
     end
   end
 end

--- a/test/fixtures/collaboration/apps/web/app/controllers/redirected_routes.rb
+++ b/test/fixtures/collaboration/apps/web/app/controllers/redirected_routes.rb
@@ -1,0 +1,9 @@
+module Collaboration::Controllers::RedirectedRoutes
+  class Index
+    include Collaboration::Action
+
+    def call(params)
+      redirect_to routes.legacy_path
+    end
+  end
+end

--- a/test/fixtures/collaboration/apps/web/config/routes.rb
+++ b/test/fixtures/collaboration/apps/web/config/routes.rb
@@ -1,10 +1,11 @@
-get '/',              to: 'home#index', as: :root
-get '/error',         to: 'home#error'
-get '/action_legacy', to: 'home#legacy'
-get '/protected',     to: 'protected#index'
-get '/body',          to: 'rendering#body'
-get '/presenter',     to: 'rendering#presenter'
-get '/custom_error',  to: 'custom_error#index'
+get '/',                   to: 'home#index', as: :root
+get '/error',              to: 'home#error'
+get '/action_legacy',      to: 'home#legacy', as: :legacy
+get '/protected',          to: 'protected#index'
+get '/body',               to: 'rendering#body'
+get '/presenter',          to: 'rendering#presenter'
+get '/custom_error',       to: 'custom_error#index'
+get '/redirected_routes',  to: 'redirected_routes#index'
 
 redirect '/legacy',   to: '/'
 

--- a/test/integration/full_stack_test.rb
+++ b/test/integration/full_stack_test.rb
@@ -233,5 +233,11 @@ describe 'A full stack Lotus application' do
     end
   end
 
+  it 'test route helpers in actions' do
+    get '/redirected_routes'
+
+    response.status.must_equal 302
+    response.headers['Location'].must_equal '/action_legacy'
+  end
 end
 


### PR DESCRIPTION
With this PR you can use routing helpers inside actions.

```ruby
module Collaboration::Controllers::RedirectedRoutes
  class Index
    include Collaboration::Action

    def call(params)
      redirect_to routes.legacy_path
    end
  end
end
```

