### PR TITLE
Add automatic :secure option

### DIFF
--- a/lib/lotus/config/cookies.rb
+++ b/lib/lotus/config/cookies.rb
@@ -22,15 +22,16 @@ module Lotus
       #
       # @param enabled [TrueClass, FalseClass] enable cookies
       # @param options [Hash] optional cookies options
+      # @param configuration [Lotus::Configuration] the application configuration
       #
       # @since 0.3.0
       # @api private
       #
       # @see https://github.com/rack/rack/blob/master/lib/rack/utils.rb #set_cookie_header!
       # @see https://www.owasp.org/index.php/HttpOnly
-      def initialize(enabled = false, options = {})
+      def initialize(enabled = false, options = {}, configuration = nil)
         @enabled         = enabled
-        @default_options = { httponly: true }.merge(options)
+        @default_options = { httponly: true, secure: !!(configuration && configuration.ssl?) }.merge(options)
       end
 
       # Return if cookies are enabled

--- a/lib/lotus/configuration.rb
+++ b/lib/lotus/configuration.rb
@@ -483,7 +483,7 @@ module Lotus
     #   end
     #
     #   Bookshelf::Application.configuration.cookies
-    #     # => #<Lotus::Config::Cookies:0x0000000329f880 @enabled=false, @default_options={:httponly=>true}>
+    #     # => #<Lotus::Config::Cookies:0x0000000329f880 @enabled=false, @default_options={:httponly=>true, :secure=>false}>
     #
     # @example Setting the value
     #   require 'lotus'
@@ -497,7 +497,7 @@ module Lotus
     #   end
     #
     #   Bookshelf::Application.configuration.cookies
-    #     # => #<Lotus::Config::Cookies:0x0000000329f880 @enabled=true, @default_options={:domain=>'lotusrb.org', :httponly=>true}>
+    #     # => #<Lotus::Config::Cookies:0x0000000329f880 @enabled=true, @default_options={:domain=>'lotusrb.org', :httponly=>true, :secure=>false}>
     #
     # @example Setting a new value after one is set.
     #   require 'lotus'
@@ -507,18 +507,20 @@ module Lotus
     #       configure do
     #         cookies false
     #         cookies true
+    #
+    #         scheme 'https'
     #       end
     #     end
     #   end
     #
     #   Bookshelf::Application.configuration.cookies
-    #     # => #<Lotus::Config::Cookies:0x0000000329f880 @enabled=true, @default_options={:httponly=>true}>
+    #     # => #<Lotus::Config::Cookies:0x0000000329f880 @enabled=true, @default_options={:httponly=>true, :secure=>true}>
     #
     def cookies(value = nil, options = {})
       if value.nil?
         @cookies ||= Config::Cookies.new
       else
-        @cookies = Config::Cookies.new(value, options)
+        @cookies = Config::Cookies.new(value, options, self)
       end
     end
 

--- a/test/config/cookies_test.rb
+++ b/test/config/cookies_test.rb
@@ -22,14 +22,35 @@ describe Lotus::Config::Cookies do
       cookies.default_options.must_equal options
     end
 
-    it 'return httponly by default' do
+    it 'return httponly and secure by default' do
       cookies = Lotus::Config::Cookies.new(true)
-      cookies.default_options.must_equal({ httponly: true })
+      cookies.default_options.must_equal({ httponly: true, secure: false })
     end
 
     it 'disabling httponly' do
-      cookies = Lotus::Config::Cookies.new(true, {httponly: false})
-      cookies.default_options.must_equal({ httponly: false })
+      cookies = Lotus::Config::Cookies.new(true, { httponly: false })
+      cookies.default_options.must_equal({ httponly: false, secure: false })
+    end
+
+    it 'enabling secure by default' do
+      configuration = Lotus::Configuration.new
+      configuration.scheme 'https'
+      cookies = Lotus::Config::Cookies.new(true, {}, configuration)
+      cookies.default_options.must_equal({ httponly: true, secure: true })
+    end
+
+    it 'disabling secure with scheme https' do
+      configuration = Lotus::Configuration.new
+      configuration.scheme 'https'
+      cookies = Lotus::Config::Cookies.new(true, { secure: false }, configuration)
+      cookies.default_options.must_equal({ httponly: true, secure: false })
+    end
+
+    it 'enabling secure with scheme http' do
+      configuration = Lotus::Configuration.new
+      configuration.scheme 'http'
+      cookies = Lotus::Config::Cookies.new(true, { secure: true }, configuration)
+      cookies.default_options.must_equal({ httponly: true, secure: true })
     end
   end
 end


### PR DESCRIPTION
close task #221

In an application with `https` scheme, `:secure` option for cookies is enabled by default
```ruby
require 'lotus'

module Bookshelf
  class Application < Lotus::Application
    configure do
      cookies true

      scheme 'https'
    end
  end
end

Bookshelf::Application.configuration.cookies
# => #<Lotus::Config::Cookies:0x0000000329f880 @enabled=true, @default_options={:httponly=>true, :secure=>true}>
```
In an application with `http` scheme, `:secure` option for cookies is disabled by default
```ruby
require 'lotus'

module Bookshelf
  class Application < Lotus::Application
    configure do
      cookies true
    end
  end
end

Bookshelf::Application.configuration.cookies
# => #<Lotus::Config::Cookies:0x0000000329f880 @enabled=true, @default_options={:httponly=>true, :secure=>false}>
```