### PR TITLE
Fixed action generator, raise exception if action name isn't supplied

### DIFF
--- a/lib/lotus/generators/action.rb
+++ b/lib/lotus/generators/action.rb
@@ -38,6 +38,7 @@ module Lotus
       # @api private
       def start
         assert_existing_app!
+        assert_action!
 
         opts = {
           app:           app,
@@ -85,6 +86,14 @@ module Lotus
       def assert_existing_app!
         unless target.join(app_root).exist?
           raise Lotus::Commands::Generate::Error.new("Unknown app: `#{ app_name }'")
+        end
+      end
+
+      # @since x.x.x
+      # @api private
+      def assert_action!
+        if @action.nil?
+          raise Lotus::Commands::Generate::Error.new("Unknown action, please add action's name with this syntax controller_name#action_name")
         end
       end
 

--- a/test/commands/generate_test.rb
+++ b/test/commands/generate_test.rb
@@ -195,6 +195,14 @@ describe Lotus::Commands::Generate do
         -> { capture_io { command.start } }.must_raise SystemExit
       end
     end
+
+    describe 'without action name' do
+    let(:target_name) { 'users' }
+
+      it 'raises error' do
+        -> { capture_io { command.start } }.must_raise SystemExit
+      end
+    end
   end
 
   describe 'model' do


### PR DESCRIPTION
# Problem
Generate an action without action's name generate wrong files
`lotus generate action admin users`
```
      insert  apps/admin/config/routes.rb
      create  spec/admin/controllers/users/_spec.rb
      create  apps/admin/controllers/users.rb
      create  apps/admin/views/users.rb
      create  apps/admin/templates/users/.html.erb
      create  spec/admin/views/users/_spec.rb
```
```ruby
module Admin::Controllers::Users
  class  # => Note this class without name, break code
    include Admin::Action

    def call(params)
    end
  end
end
```
# Solution

Raise an exception if action's name isn't supplied:
```
lotus generate action admin users
# => Unknown action, please add action's name with this syntax controller_name#action_name
```