### PR TITLE
Enhanced cookies syntax options

### DIFF
--- a/lib/lotus/config/cookies.rb
+++ b/lib/lotus/config/cookies.rb
@@ -20,17 +20,37 @@ module Lotus
       # Prevent attackers to steal cookies via JavaScript,
       # Eg. alert(document.cookie) will fail
       #
-      # @param enabled [TrueClass, FalseClass] enable cookies
-      # @param options [Hash] optional cookies options
+      # @param options [Hash, TrueClass, FalseClass] optional cookies options
       #
-      # @since 0.3.0
+      # @since x.x.x
       # @api private
       #
       # @see https://github.com/rack/rack/blob/master/lib/rack/utils.rb #set_cookie_header!
       # @see https://www.owasp.org/index.php/HttpOnly
-      def initialize(enabled = false, options = {})
-        @enabled         = enabled
-        @default_options = { httponly: true }.merge(options)
+      #
+      # @example with boolean option
+      #
+      #  require 'lotus/config/cookies'
+      #
+      #  cookies_config = Lotus::Config::Cookies.new(true)
+      #  # => #<Lotus::Config::Cookies:0x007fb902c55978 @options=true, @default_options={:httponly=>true}>
+      #  cookies_config.enabled? # => true
+      #
+      #  cookies_config = Lotus::Config::Cookies.new(false)
+      #  # => #<Lotus::Config::Cookies:0x007fb902c55978 @options=false, @default_options={:httponly=>true}>
+      #  cookies_config.enabled? # => false
+      #
+      # @example with hash option
+      #
+      #  require 'lotus/config/cookies'
+      #
+      #  cookies_config = Lotus::Config::Cookies.new(max_age: true)
+      #  # => #<Lotus::Config::Cookies:0x007fb902c37f40 @options={:max_age=>true}, @default_options={:httponly=>true, :max_age=>true}>
+      #  cookies_config.enabled? # => true
+      def initialize(options = {})
+        @options         = options
+        @default_options = { httponly: true }
+        @default_options.merge!(options) if options.is_a? Hash
       end
 
       # Return if cookies are enabled
@@ -40,7 +60,7 @@ module Lotus
       # @since 0.3.0
       # @api private
       def enabled?
-        !!@enabled
+        @options.respond_to?(:empty?) ? !@options.empty? : @options
       end
     end
   end

--- a/lib/lotus/configuration.rb
+++ b/lib/lotus/configuration.rb
@@ -465,10 +465,9 @@ module Lotus
     # an argument, it will set the corresponding instance variable. When
     # called without, it will return the already set value, or the default.
     #
-    # @overload cookies(value, options)
+    # @overload cookies(options)
     #   Sets the given value with their options.
-    #   @param value [TrueClass, FalseClass]
-    #   @param options [Hash]
+    #   @param options [Hash, TrueClass, FalseClass]
     #
     # @overload cookies
     #   Gets the value.
@@ -483,7 +482,7 @@ module Lotus
     #   end
     #
     #   Bookshelf::Application.configuration.cookies
-    #     # => #<Lotus::Config::Cookies:0x0000000329f880 @enabled=false, @default_options={:httponly=>true}>
+    #     # => #<Lotus::Config::Cookies:0x0000000329f880 @options={}, @default_options={:httponly=>true}>
     #
     # @example Setting the value
     #   require 'lotus'
@@ -491,13 +490,13 @@ module Lotus
     #   module Bookshelf
     #     class Application < Lotus::Application
     #       configure do
-    #         cookies true, { domain: 'lotusrb.org' }
+    #         cookies domain: 'lotusrb.org'
     #       end
     #     end
     #   end
     #
     #   Bookshelf::Application.configuration.cookies
-    #     # => #<Lotus::Config::Cookies:0x0000000329f880 @enabled=true, @default_options={:domain=>'lotusrb.org', :httponly=>true}>
+    #     # => #<Lotus::Config::Cookies:0x0000000329f880 @options={:domain=>'lotusrb.org'}, @default_options={:domain=>'lotusrb.org', :httponly=>true}>
     #
     # @example Setting a new value after one is set.
     #   require 'lotus'
@@ -512,13 +511,13 @@ module Lotus
     #   end
     #
     #   Bookshelf::Application.configuration.cookies
-    #     # => #<Lotus::Config::Cookies:0x0000000329f880 @enabled=true, @default_options={:httponly=>true}>
+    #     # => #<Lotus::Config::Cookies:0x0000000329f880 @options=true, @default_options={:httponly=>true}>
     #
-    def cookies(value = nil, options = {})
-      if value.nil?
+    def cookies(options = nil)
+      if options.nil?
         @cookies ||= Config::Cookies.new
       else
-        @cookies = Config::Cookies.new(value, options)
+        @cookies = Config::Cookies.new(options)
       end
     end
 

--- a/lib/lotus/loader.rb
+++ b/lib/lotus/loader.rb
@@ -3,7 +3,6 @@ require 'lotus/utils/kernel'
 require 'lotus/utils/string'
 require 'lotus/routes'
 require 'lotus/routing/default'
-require 'lotus/action/cookies'
 require 'lotus/action/session'
 require 'lotus/config/security'
 
@@ -56,6 +55,7 @@ module Lotus
           })
 
           if config.cookies.enabled?
+            require 'lotus/action/cookies'
             prepare { include Lotus::Action::Cookies }
             cookies config.cookies.default_options
           end

--- a/test/config/cookies_test.rb
+++ b/test/config/cookies_test.rb
@@ -13,12 +13,17 @@ describe Lotus::Config::Cookies do
       cookies = Lotus::Config::Cookies.new(true)
       cookies.enabled?.must_equal true
     end
+
+    it 'is true if options are passed' do
+      cookies = Lotus::Config::Cookies.new(max_age: 300)
+      cookies.enabled?.must_equal true
+    end
   end
 
   describe "#options" do
     it 'get options if they are passed' do
       options = { domain: 'lotusrb.org', path: '/controller', secure: true, httponly: true }
-      cookies = Lotus::Config::Cookies.new(true, options)
+      cookies = Lotus::Config::Cookies.new(options)
       cookies.default_options.must_equal options
     end
 
@@ -28,7 +33,7 @@ describe Lotus::Config::Cookies do
     end
 
     it 'disabling httponly' do
-      cookies = Lotus::Config::Cookies.new(true, {httponly: false})
+      cookies = Lotus::Config::Cookies.new(httponly: false)
       cookies.default_options.must_equal({ httponly: false })
     end
   end

--- a/test/fixtures/cookies/application.rb
+++ b/test/fixtures/cookies/application.rb
@@ -2,7 +2,7 @@ module CookiesApp
   class Application < Lotus::Application
     configure do
       # Activate Cookies
-      cookies true, { domain: 'lotusrb.org', path: '/another_controller', secure: true }
+      cookies domain: 'lotusrb.org', path: '/another_controller', secure: true
 
       routes do
         get '/get_cookies',              to: 'cookies#get'


### PR DESCRIPTION
closes #221 

This PR enhances cookies syntax options.

Now cookies are activated with this syntax:
```ruby
cookies true
# or
cookies max_age: 300
```