### PR TITLE
Model generator doesn't respect Ruby file naming

### DIFF
--- a/lib/lotus/generators/model.rb
+++ b/lib/lotus/generators/model.rb
@@ -10,7 +10,7 @@ module Lotus
       def initialize(command)
         super
 
-        @model = app_name
+        @model = Utils::String.new(app_name).underscore
         @model_name = Utils::String.new(@model).classify
 
         cli.class.source_root(source)

--- a/lib/lotus/generators/model/entity.rb.tt
+++ b/lib/lotus/generators/model/entity.rb.tt
@@ -1,5 +1,3 @@
-require 'lotus/entity'
-
 class <%= config[:model_name] %>
   include Lotus::Entity
 end

--- a/lib/lotus/generators/model/repository.rb.tt
+++ b/lib/lotus/generators/model/repository.rb.tt
@@ -1,5 +1,3 @@
-require 'lotus/repository'
-
 class <%= config[:model_name] %>Repository
   include Lotus::Repository
 end

--- a/test/commands/generate_test.rb
+++ b/test/commands/generate_test.rb
@@ -209,7 +209,6 @@ describe Lotus::Commands::Generate do
     describe 'lib/generate/entities/post.rb' do
       it 'generates it' do
         content = @root.join('lib/generate/entities/post.rb').read
-        content.must_match %(require 'lotus/entity')
         content.must_match %(class Post)
         content.must_match %(  include Lotus::Entity)
         content.must_match %(end)
@@ -219,7 +218,6 @@ describe Lotus::Commands::Generate do
     describe 'lib/generate/repositories/post.rb' do
       it 'generates it' do
         content = @root.join('lib/generate/repositories/post_repository.rb').read
-        content.must_match %(require 'lotus/repository')
         content.must_match %(class PostRepository)
         content.must_match %(  include Lotus::Repository)
         content.must_match %(end)

--- a/test/integration/cli/generate_test.rb
+++ b/test/integration/cli/generate_test.rb
@@ -81,12 +81,24 @@ template=#{ template_engine }
       before do
         generate_model
       end
+      describe 'when model names are Underscored names.' do
+        it 'generates model' do
+          @root.join('lib/delivery/entities/test.rb').must_be                      :exist?
+          @root.join('lib/delivery/repositories/test_repository.rb').must_be       :exist?
+          @root.join('spec/delivery/entities/test_spec.rb').must_be                :exist?
+          @root.join('spec/delivery/repositories/test_repository_spec.rb').must_be :exist?
+        end
+      end
 
-      it 'generates model' do
-        @root.join('lib/delivery/entities/test.rb').must_be                      :exist?
-        @root.join('lib/delivery/repositories/test_repository.rb').must_be       :exist?
-        @root.join('spec/delivery/entities/test_spec.rb').must_be                :exist?
-        @root.join('spec/delivery/repositories/test_repository_spec.rb').must_be :exist?
+      describe 'when model names are CamelCase names.' do
+        let(:klass) { 'TestCase' }
+
+        it 'generates model' do
+          @root.join('lib/delivery/entities/test_case.rb').must_be                      :exist?
+          @root.join('lib/delivery/repositories/test_case_repository.rb').must_be       :exist?
+          @root.join('spec/delivery/entities/test_case_spec.rb').must_be                :exist?
+          @root.join('spec/delivery/repositories/test_case_repository_spec.rb').must_be :exist?
+        end
       end
     end
 


### PR DESCRIPTION
- Use underscored model file name
Base on https://github.com/lotus/lotus/issues/225