### PR TITLE
Model generator creates wrong RSpec files

### DIFF
--- a/lib/lotus/generators/model/entity_spec.rspec.tt
+++ b/lib/lotus/generators/model/entity_spec.rspec.tt
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe <%= config[:model_name] %> do
+RSpec.describe <%= config[:model_name] %> do
   # place your tests here
 end

--- a/lib/lotus/generators/model/repository_spec.rspec.tt
+++ b/lib/lotus/generators/model/repository_spec.rspec.tt
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe <%= config[:model_name] %>Repository do
+RSpec.describe <%= config[:model_name] %>Repository do
   # place your tests here
 end

--- a/test/commands/generate_test.rb
+++ b/test/commands/generate_test.rb
@@ -248,7 +248,7 @@ describe Lotus::Commands::Generate do
         it 'generates it' do
           content = @root.join('spec/generate/entities/post_spec.rb').read
           content.must_match %(require 'spec_helper')
-          content.must_match %(describe Post do)
+          content.must_match %(RSpec.describe Post do)
           content.must_match %(end)
         end
       end
@@ -270,7 +270,7 @@ describe Lotus::Commands::Generate do
         it 'generates it' do
           content = @root.join('spec/generate/repositories/post_repository_spec.rb').read
           content.must_match %(require 'spec_helper')
-          content.must_match %(describe PostRepository do)
+          content.must_match %(RSpec.describe PostRepository do)
           content.must_match %(end)
         end
       end


### PR DESCRIPTION
When model generator create Rspec files it must be:
```ruby
require 'spec_helper'

RSpec.describe User do
  # place your tests here
end
```