### PR TITLE
Action generator doesn't respect Ruby file naming

### DIFF
--- a/lib/lotus/generators/action.rb
+++ b/lib/lotus/generators/action.rb
@@ -27,7 +27,8 @@ module Lotus
       def initialize(command)
         super
 
-        @controller, @action = name.split(ACTION_SEPARATOR)
+        @name = Utils::String.new(name).underscore
+        @controller, @action = @name.split(ACTION_SEPARATOR)
         @controller_name     = Utils::String.new(@controller).classify
         @action_name         = Utils::String.new(@action).classify
 
@@ -107,7 +108,7 @@ module Lotus
 
         # Insert at the top of the file
         cli.insert_into_file _routes_path, before: /\A(.*)/ do
-          "get '/#{ @controller }', to: '#{ name }'\n"
+          "get '/#{ @controller }', to: '#{ @name }'\n"
         end
       end
 

--- a/test/integration/cli/generate_test.rb
+++ b/test/integration/cli/generate_test.rb
@@ -34,8 +34,16 @@ template=#{ template_engine }
       `bundle exec lotus generate action #{ app_name } dashboard#index`
     end
 
+    def generate_action_with_camlcase
+      `bundle exec lotus generate action #{ app_name } AncientBooks#ToggleVisibility`
+    end
+
     def generate_action_without_view
       `bundle exec lotus generate action #{ app_name } dashboard#foo --skip-view`
+    end
+
+    def generate_action_with_camlcase_without_view
+      `bundle exec lotus generate action #{ app_name } DashBoard#TestCase --skip-view`
     end
 
     def generate_model
@@ -61,20 +69,46 @@ template=#{ template_engine }
       chdir_to_root
     end
 
-    it 'generates an action' do
-      @root.join('apps/web/controllers/dashboard/index.rb').must_be      :exist?
-      @root.join('apps/web/views/dashboard/index.rb').must_be            :exist?
-      @root.join('apps/web/templates/dashboard/index.html.erb').must_be  :exist?
-      @root.join('spec/web/controllers/dashboard/index_spec.rb').must_be :exist?
-      @root.join('spec/web/views/dashboard/index_spec.rb').must_be       :exist?
-    end
+    describe 'when application generates new action' do
+      describe 'when controllers, action name are Underscored names.' do
+        it 'generates an action' do
+          @root.join('apps/web/controllers/dashboard/index.rb').must_be      :exist?
+          @root.join('apps/web/views/dashboard/index.rb').must_be            :exist?
+          @root.join('apps/web/templates/dashboard/index.html.erb').must_be  :exist?
+          @root.join('spec/web/controllers/dashboard/index_spec.rb').must_be :exist?
+          @root.join('spec/web/views/dashboard/index_spec.rb').must_be       :exist?
+        end
 
-    it 'generates an action without view' do
-      @root.join('apps/web/controllers/dashboard/foo.rb').must_be      :exist?
-      @root.join('apps/web/views/dashboard/foo.rb').wont_be            :exist?
-      @root.join('apps/web/templates/dashboard/foo.html.erb').wont_be  :exist?
-      @root.join('spec/web/controllers/dashboard/foo_spec.rb').must_be :exist?
-      @root.join('spec/web/views/dashboard/foo_spec.rb').wont_be       :exist?
+        it 'generates an action without view' do
+          @root.join('apps/web/controllers/dashboard/foo.rb').must_be      :exist?
+          @root.join('apps/web/views/dashboard/foo.rb').wont_be            :exist?
+          @root.join('apps/web/templates/dashboard/foo.html.erb').wont_be  :exist?
+          @root.join('spec/web/controllers/dashboard/foo_spec.rb').must_be :exist?
+          @root.join('spec/web/views/dashboard/foo_spec.rb').wont_be       :exist?
+        end
+      end
+
+      describe 'when controllers, action name are CamelCase names.' do
+        before do
+          generate_action_with_camlcase
+          generate_action_with_camlcase_without_view
+        end
+        it 'generates an action' do
+          @root.join('apps/web/controllers/ancient_books/toggle_visibility.rb').must_be      :exist?
+          @root.join('apps/web/views/ancient_books/toggle_visibility.rb').must_be            :exist?
+          @root.join('apps/web/templates/ancient_books/toggle_visibility.html.erb').must_be  :exist?
+          @root.join('spec/web/controllers/ancient_books/toggle_visibility_spec.rb').must_be :exist?
+          @root.join('spec/web/views/ancient_books/toggle_visibility_spec.rb').must_be       :exist?
+        end
+
+        it 'generates an action without view' do
+          @root.join('apps/web/controllers/dash_board/test_case.rb').must_be      :exist?
+          @root.join('apps/web/views/dash_board/test_case.rb').wont_be            :exist?
+          @root.join('apps/web/templates/dash_board/test_case.html.erb').wont_be  :exist?
+          @root.join('spec/web/controllers/dash_board/test_case_spec.rb').must_be :exist?
+          @root.join('spec/web/views/dash_board/test_case_spec.rb').wont_be       :exist?
+        end
+      end
     end
 
     describe 'when application generates new model' do


### PR DESCRIPTION
Generator correct Ruby file naming

```ruby
% bundle exec lotus generate action web AncientBooks#ToggleVisibility
      insert  apps/web/config/routes.rb
      create  spec/web/controllers/ancient_books/toggle_visibility_spec.rb
      create  apps/web/controllers/ancient_books/toggle_visibility.rb
      create  apps/web/views/ancient_books/toggle_visibility.rb
      create  apps/web/templates/ancient_books/toggle_visibility.html.erb
      create  spec/web/views/ancient_books/toggle_visibility_spec.rb
```

Closes #226