### PR TITLE
CSRF protection

### DIFF
--- a/lib/lotus/action/csrf_protection.rb
+++ b/lib/lotus/action/csrf_protection.rb
@@ -1,0 +1,167 @@
+require 'securerandom'
+
+module Lotus
+  module Action
+    # Invalid CSRF Token
+    #
+    # @since x.x.x
+    class InvalidCSRFTokenError < ::StandardError
+    end
+
+    # CSRF Protection
+    #
+    # This security mechanism is enabled automatically if sessions are turned on.
+    #
+    # It stores a "challenge" token in session. For each "state changing request"
+    # (eg. <tt>POST</tt>, <tt>PATCH</tt> etc..), we should send a special param:
+    # <tt>_csrf_token</tt>.
+    #
+    # If the param matches with the challenge token, the flow can continue.
+    # Otherwise the application detects an attack attempt, it reset the session
+    # and <tt>Lotus::Action::InvalidCSRFTokenError</tt> is raised.
+    #
+    # We can specify a custom handling strategy, by overriding <tt>#handle_invalid_csrf_token</tt>.
+    #
+    # Form helper (<tt>#form_for</tt>) automatically sets a hidden field with the
+    # correct token. A special view method (<tt>#csrf_token</tt>) is available in
+    # case the form markup is manually crafted.
+    #
+    # We can disable this check on action basis, by overriding <tt>#verify_csrf_token?</tt>.
+    #
+    # @since x.x.x
+    #
+    # @see https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29
+    # @see https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet
+    #
+    # @example Custom Handling
+    #   module Web::Controllers::Books
+    #     class Create
+    #       include Web::Action
+    #
+    #       def call(params)
+    #         # ...
+    #       end
+    #
+    #       private
+    #
+    #       def handle_invalid_csrf_token
+    #         Web::Logger.warn "CSRF attack: expected #{ session[:_csrf_token] }, was #{ params[:_csrf_token] }"
+    #         # manual handling
+    #       end
+    #     end
+    #   end
+    #
+    # @example Bypass Security Check
+    #   module Web::Controllers::Books
+    #     class Create
+    #       include Web::Action
+    #
+    #       def call(params)
+    #         # ...
+    #       end
+    #
+    #       private
+    #
+    #       def verify_csrf_token?
+    #         false
+    #       end
+    #     end
+    #   end
+    module CSRFProtection
+      # Session and params key for CSRF token.
+      #
+      # This key is shared with <tt>lotus-controller</tt> and <tt>lotus-helpers</tt>
+      #
+      # @since x.x.x
+      # @api private
+      CSRF_TOKEN = :_csrf_token
+
+      # Idempotent HTTP methods
+      #
+      # By default, the check isn't performed if the request method is included
+      # in this list.
+      #
+      # @since x.x.x
+      # @api private
+      IDEMPOTENT_HTTP_METHODS = Hash[
+        'GET'     => true,
+        'HEAD'    => true,
+        'TRACE'   => true,
+        'OPTIONS' => true
+      ].freeze
+
+      # @since x.x.x
+      # @api private
+      def self.included(action)
+        action.class_eval do
+          before :set_csrf_token, :verify_csrf_token
+        end
+      end
+
+      private
+      # Set CSRF Token in session
+      #
+      # @since x.x.x
+      # @api private
+      def set_csrf_token
+        session[CSRF_TOKEN] ||= generate_csrf_token
+      end
+
+      # Verify if CSRF token from params, matches the one stored in session.
+      # If not, it raises an error.
+      #
+      # Don't override this method.
+      #
+      # To bypass the security check, please override <tt>#verify_csrf_token?</tt>.
+      # For custom handling of an attack, please override <tt>#handle_invalid_csrf_token</tt>.
+      #
+      # @since x.x.x
+      # @api private
+      def verify_csrf_token
+        handle_invalid_csrf_token if invalid_csrf_token?
+      end
+
+      # Verify if CSRF token from params, matches the one stored in session.
+      #
+      # Don't override this method.
+      #
+      # @since x.x.x
+      # @api private
+      def invalid_csrf_token?
+        verify_csrf_token? &&
+          session[CSRF_TOKEN] != params[CSRF_TOKEN]
+      end
+
+      # Generates a random CSRF Token
+      #
+      # @since x.x.x
+      # @api private
+      def generate_csrf_token
+        SecureRandom.hex(32)
+      end
+
+      # Decide if perform the check or not.
+      #
+      # Override and return <tt>false</tt> if you want to bypass security check.
+      #
+      # @since x.x.x
+      def verify_csrf_token?
+        !IDEMPOTENT_HTTP_METHODS[request_method]
+      end
+
+      # Handle CSRF attack.
+      #
+      # The default policy resets the session and raises an exception.
+      #
+      # Override this method, for custom handling.
+      #
+      # @raise [Lotus::Action::InvalidCSRFTokenError]
+      #
+      # @since x.x.x
+      def handle_invalid_csrf_token
+        session.clear
+        raise InvalidCSRFTokenError.new
+      end
+    end
+  end
+end

--- a/lib/lotus/frameworks.rb
+++ b/lib/lotus/frameworks.rb
@@ -2,6 +2,7 @@ require 'lotus/router'
 require 'lotus/view'
 require 'lotus/controller'
 require 'lotus/action/glue'
+require 'lotus/action/csrf_protection'
 
 Lotus::Controller.configure do
   prepare do

--- a/lib/lotus/loader.rb
+++ b/lib/lotus/loader.rb
@@ -60,7 +60,14 @@ module Lotus
             prepare { include Lotus::Action::Cookies }
             cookies config.cookies.default_options
           end
-          prepare { include Lotus::Action::Session } if config.sessions.enabled?
+
+          if config.sessions.enabled?
+            prepare do
+              include Lotus::Action::Session
+              include Lotus::Action::CSRFProtection
+            end
+          end
+
           prepare { include Lotus::Action::RoutingHelpers }
 
           config.controller.__apply(self)

--- a/lotusrb.gemspec
+++ b/lotusrb.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'lotus-utils',      '~> 0.4'
   spec.add_dependency 'lotus-router',     '~> 0.4'
-  spec.add_dependency 'lotus-controller', '~> 0.4'
+  spec.add_dependency 'lotus-controller', '~> 0.4', '>= 0.4.4'
   spec.add_dependency 'lotus-view',       '~> 0.4'
   spec.add_dependency 'lotus-helpers',    '~> 0.2'
   spec.add_dependency 'shotgun',          '~> 0.9'

--- a/test/controller/csrf_protection_test.rb
+++ b/test/controller/csrf_protection_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+require 'rack/mock'
+
+describe Lotus::Action::CSRFProtection do
+  describe "when active" do
+    before do
+      @action = CSRFAction.new
+    end
+
+    it "is successful for GET request" do
+      env = Rack::MockRequest.env_for('/', {})
+      status, _, _ = @action.call(env)
+
+      status.must_equal 200
+    end
+
+    it "is successful for HEAD request" do
+      env = Rack::MockRequest.env_for('/', method: 'HEAD')
+      status, _, _ = @action.call(env)
+
+      status.must_equal 200
+    end
+
+    it "is successful if token matches" do
+      token = @action.csrf_token
+      env   = Rack::MockRequest.env_for('/', method: 'POST', params: { '_csrf_token' => token })
+      status, _, _ = @action.call(env)
+
+      status.must_equal 200
+    end
+
+    [ 'POST', 'PATCH', 'PUT', 'DELETE' ].each do |verb|
+      it "raises error if token doesn't match (#{ verb })" do
+        env = Rack::MockRequest.env_for('/', method: verb, params: { '_csrf_token' => 'nope' })
+
+        -> { @action.call(env) }.must_raise Lotus::Action::InvalidCSRFTokenError
+        @action.__send__(:session).must_be :empty? # reset session
+      end
+    end
+
+    [ 'GET', 'HEAD', 'TRACE', 'OPTIONS' ].each do |verb|
+      it "doesn't raise error if token doesn't match (#{ verb })" do
+        env = Rack::MockRequest.env_for('/', method: verb, params: { '_csrf_token' => 'nope' })
+        status, _, _ = @action.call(env)
+
+        status.must_equal 200
+      end
+    end
+  end
+
+  describe "with concrete params" do
+    before do
+      @action = FilteredCSRFAction.new
+    end
+
+    it "is successful if token matches" do
+      token = @action.csrf_token
+      env   = Rack::MockRequest.env_for('/', method: 'POST', params: { '_csrf_token' => token })
+      status, _, _ = @action.call(env)
+
+      status.must_equal 200
+    end
+  end
+
+  describe "when disabled" do
+    before do
+      @action = DisabledCSRFAction.new
+    end
+
+    it "raises error if token isn't sent" do
+      env = Rack::MockRequest.env_for('/', method: 'POST')
+      status, _, _ = @action.call(env)
+
+      status.must_equal 200
+    end
+  end
+end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -72,3 +72,85 @@ class TinyApp < Lotus::Application
     end
   end
 end
+
+class CSRFAction
+  include Lotus::Action
+  include Lotus::Action::Session
+  include Lotus::Action::CSRFProtection
+
+  configuration.handle_exceptions false
+
+  expose :csrf_token
+
+  # Ensure _csrf_token param won't be filtered
+  params do
+    param :name
+  end
+
+  def initialize
+    generate_csrf_token
+  end
+
+  def call(env)
+    # ...
+  end
+
+  private
+
+  def set_csrf_token
+    session[:_csrf_token] ||= @csrf_token || generate_csrf_token
+  end
+
+  def generate_csrf_token
+    @csrf_token = super
+  end
+end
+
+class FilteredParams < Lotus::Action::Params
+  param :name
+end
+
+class FilteredCSRFAction
+  include Lotus::Action
+  include Lotus::Action::Session
+  include Lotus::Action::CSRFProtection
+
+  expose :csrf_token
+
+  # Ensure _csrf_token param won't be filtered
+  params FilteredParams
+
+  def initialize
+    generate_csrf_token
+  end
+
+  def call(env)
+    # ...
+  end
+
+  private
+
+  def set_csrf_token
+    session[:_csrf_token] ||= @csrf_token || generate_csrf_token
+  end
+
+  def generate_csrf_token
+    @csrf_token = super
+  end
+end
+
+class DisabledCSRFAction
+  include Lotus::Action
+  include Lotus::Action::Session
+  include Lotus::Action::CSRFProtection
+
+  def call(env)
+    # ...
+  end
+
+  private
+
+  def verify_csrf_token?
+    false
+  end
+end

--- a/test/fixtures/collaboration/apps/web/app/controllers/authors.rb
+++ b/test/fixtures/collaboration/apps/web/app/controllers/authors.rb
@@ -1,0 +1,25 @@
+module Collaboration::Controllers::Authors
+  class Create
+    include Collaboration::Action
+
+    def call(params)
+      # pretend it was going to persist
+    end
+  end
+
+  class Update
+    include Collaboration::Action
+
+    def call(params)
+      # pretend it was going to persist
+    end
+  end
+
+  class Destroy
+    include Collaboration::Action
+
+    def call(params)
+      # pretend it was going to persist
+    end
+  end
+end

--- a/test/fixtures/collaboration/apps/web/app/controllers/books.rb
+++ b/test/fixtures/collaboration/apps/web/app/controllers/books.rb
@@ -1,6 +1,4 @@
 module Collaboration::Controllers::Books
-  include Collaboration::Controller
-
   class New
     include Collaboration::Action
     expose :book
@@ -52,7 +50,7 @@ module Collaboration::Controllers::Books
     include Collaboration::Action
 
     def call(params)
-      @book = Book.new(params)
+      @book = Book.new(params[:book])
       @book = BookRepository.create(@book)
 
       redirect_to routes.url(:book, :id => @book.id)
@@ -64,7 +62,7 @@ module Collaboration::Controllers::Books
 
     def call(params)
       @book = BookRepository.find(params[:id])
-      @book.update(params)
+      @book.update(params[:book])
       @book = BookRepository.update(@book)
 
       redirect_to routes.url(:book, :id => @book.id)

--- a/test/fixtures/collaboration/apps/web/app/templates/books/edit.html.erb
+++ b/test/fixtures/collaboration/apps/web/app/templates/books/edit.html.erb
@@ -1,4 +1,6 @@
-<form accept-charset="UTF-8" action="/books/<%= book.id %>" method="patch">
-  <input name="book[name]" placeholder="Name" type="text" value="<%= book.name %>" />
-  <button type="submit">Update</button>
-</form>
+<%=
+  form_for :book, routes.book_path(id: book.id), method: :patch, values: {book: book} do
+    text_field :name, placeholder: "Name"
+    submit "Update"
+  end
+%>

--- a/test/fixtures/collaboration/apps/web/app/templates/books/new.html.erb
+++ b/test/fixtures/collaboration/apps/web/app/templates/books/new.html.erb
@@ -1,4 +1,6 @@
-<form accept-charset="UTF-8" action="/books" method="post">
-  <input name="book[name]" placeholder="Name" type="text" value="<%= book.name %>" />
-  <button type="submit">Create</button>
-</form>
+<%=
+  form_for :book, routes.books_path do
+    text_field :name, placeholder: "Name"
+    submit "Create"
+  end
+%>

--- a/test/fixtures/collaboration/apps/web/application.rb
+++ b/test/fixtures/collaboration/apps/web/application.rb
@@ -53,8 +53,6 @@ module Collaboration
       end
 
       controller.prepare do
-        expose :session
-        include Lotus::Action::CSRFProtection
         include Module.new {
           private
           def generate_csrf_token

--- a/test/fixtures/collaboration/apps/web/application.rb
+++ b/test/fixtures/collaboration/apps/web/application.rb
@@ -1,5 +1,6 @@
 require 'lotus'
 require 'lotus/model'
+require 'lotus/helpers'
 
 ADAPTER_TYPE =  if RUBY_ENGINE == 'jruby'
                   require 'jdbc/sqlite3'
@@ -31,6 +32,7 @@ module Collaboration
       routes  'config/routes'
 
       serve_assets true
+      sessions :cookie, secret: SecureRandom.hex
 
       assets << [
         'public',
@@ -41,11 +43,25 @@ module Collaboration
       adapter type: :sql, uri: SQLITE_CONNECTION_STRING
       mapping 'config/mapping'
 
-      #
       # SIMULATE DISABLED SECURITY HEADERS
       #
       # security.x_frame_options         "DENY"
       # security.content_security_policy "connect-src 'self'"
+
+      view.prepare do
+        include Lotus::Helpers
+      end
+
+      controller.prepare do
+        expose :session
+        include Lotus::Action::CSRFProtection
+        include Module.new {
+          private
+          def generate_csrf_token
+            't0k3n'
+          end
+        }
+      end
     end
   end
 end

--- a/test/fixtures/collaboration/apps/web/config/routes.rb
+++ b/test/fixtures/collaboration/apps/web/config/routes.rb
@@ -10,3 +10,4 @@ get '/redirected_routes',  to: 'redirected_routes#index'
 redirect '/legacy',   to: '/'
 
 resources :books
+resources :authors, only: [:create, :update, :destroy]

--- a/test/fixtures/sessions/application.rb
+++ b/test/fixtures/sessions/application.rb
@@ -8,6 +8,14 @@ module SessionsApp
         get    '/get_session'  , to: 'sessions#show'
         delete '/clear_session', to: 'sessions#destroy'
       end
+
+      controller.prepare do
+        include Module.new {
+          def generate_csrf_token
+            'app123'
+          end
+        }
+      end
     end
 
     load!

--- a/test/integration/full_stack_test.rb
+++ b/test/integration/full_stack_test.rb
@@ -181,8 +181,10 @@ describe 'A full stack Lotus application' do
 
       response.status.must_equal 200
 
-      response.body.must_include "<form accept-charset=\"UTF-8\" action=\"/books/#{@book.id}\" method=\"patch\">"
-      response.body.must_include '<input name="book[name]" placeholder="Name" type="text" value="The path to success" />'
+      response.body.must_include %(<form action="/books/#{ @book.id }" method="POST" accept-charset="utf-8" id="book-form">)
+      response.body.must_include %(<input type="hidden" name="_method" value="PATCH">)
+      response.body.must_include %(<input type="hidden" name="_csrf_token" value="t0k3n">)
+      response.body.must_include %(<input type="text" name="book[name]" id="book-name" value="The path to success" placeholder="Name">)
     end
 
     it 'handles new action' do
@@ -190,12 +192,13 @@ describe 'A full stack Lotus application' do
 
       response.status.must_equal 200
 
-      response.body.must_include '<form accept-charset="UTF-8" action="/books" method="post">'
-      response.body.must_include '<input name="book[name]" placeholder="Name" type="text" value="" />'
+      response.body.must_include %(<form action="/books" method="POST" accept-charset="utf-8" id="book-form">)
+      response.body.must_include %(<input type="hidden" name="_csrf_token" value="t0k3n">)
+      response.body.must_include %(<input type="text" name="book[name]" id="book-name" value="" placeholder="Name">)
     end
 
     it 'handles update action' do
-      patch "/books/#{@book.id}", name: 'The path to failure'
+      patch "/books/#{@book.id}", book: {name: 'The path to enlightenment'}, '_csrf_token' => 't0k3n'
 
       response.status.must_equal 302
       response.body.must_equal "Found"
@@ -204,11 +207,11 @@ describe 'A full stack Lotus application' do
 
       response.status.must_equal 200
       response.body.must_include "<p id=\"book_id\">#{@book.id}</p>"
-      response.body.must_include '<p id="book_name">The path to failure</p>'
+      response.body.must_include '<p id="book_name">The path to enlightenment</p>'
     end
 
     it 'handles create action' do
-      post "/books", name: 'The art of Zen'
+      post "/books", book: {name: 'The art of Zen'}, '_csrf_token' => 't0k3n'
 
       response.status.must_equal 302
       response.body.must_equal "Found"
@@ -219,9 +222,8 @@ describe 'A full stack Lotus application' do
       response.body.must_include '<p id="book_name">The art of Zen</p>'
     end
 
-
     it 'handles destroy action' do
-      delete "/books/#{@book.id}"
+      delete "/books/#{@book.id}", '_csrf_token' => 't0k3n'
 
       response.status.must_equal 302
       response.body.must_equal "Found"
@@ -230,6 +232,29 @@ describe 'A full stack Lotus application' do
 
       response.status.must_equal 200
       response.body.must_include 'There are 0 books'
+    end
+  end
+
+  describe "CSRF Protection" do
+    it "handles create action" do
+      post "/authors", name: "L"
+
+      response.status.must_equal 500
+      response.body.must_match "Internal Server Error"
+    end
+
+    it "handles update action" do
+      patch "/authors/15", name: "MG"
+
+      response.status.must_equal 500
+      response.body.must_match "Internal Server Error"
+    end
+
+    it "handles destroy action" do
+      delete "/authors/99"
+
+      response.status.must_equal 500
+      response.body.must_match "Internal Server Error"
     end
   end
 

--- a/test/integration/sessions_test.rb
+++ b/test/integration/sessions_test.rb
@@ -35,22 +35,22 @@ describe 'Sessions' do
   end
 
   it 'allows to set session' do
-    post '/set_session', { name: 'Lotus' }
+    post '/set_session', { name: 'Lotus', _csrf_token: 'app123' }
 
     response.body.must_equal 'Session created for: Lotus'
   end
 
   it 'preserves session between requests' do
-    post '/set_session', { name: 'Lotus' }
+    post '/set_session', { name: 'Lotus', _csrf_token: 'app123' }
     get '/get_session', nil, { 'HTTP_COOKIE' => response.headers['Set-Cookie'] }
 
     response.body.must_equal 'Lotus'
   end
 
   it 'allows to clear session' do
-    post '/set_session', { name: 'Lotus' }
+    post '/set_session', { name: 'Lotus', _csrf_token: 'app123' }
 
-    delete '/clear_session', nil, { 'HTTP_COOKIE' => response.headers['Set-Cookie'] }
+    delete '/clear_session', { _csrf_token: 'app123'}, { 'HTTP_COOKIE' => response.headers['Set-Cookie'] }
     response.body.must_equal 'Session cleared for: Lotus'
 
     get '/get_session', nil, { 'HTTP_COOKIE' => response.headers['Set-Cookie'] }


### PR DESCRIPTION
### CSRF Protection

This security mechanism is enabled automatically if sessions are turned on.

It stores a "challenge" token in session. For each "state changing request" (eg. `POST`, `PATCH` etc..), we should send a special param: `_csrf_token`.

If the param matches with the challenge token, the flow can continue.
Otherwise the application detects an attack attempt, it reset the session and `Lotus::Action::InvalidCSRFTokenError` is raised.

We can specify a custom handling strategy, by overriding `#handle_invalid_csrf_token`.

Form helper (`#form_for`) automatically sets a hidden field with the correct token. A special view method (`#csrf_token`) is available in case the form markup is manually crafted.

We can disable this check on action basis, by overriding `#verify_csrf_token?`.

### References

  * https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29
  * https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet

### Examples

#### Custom Handling

```ruby
module Web::Controllers::Books
  class Create
    include Web::Action

    def call(params)
      # ...
    end

    private

    def handle_invalid_csrf_token
      Web::Logger.warn "CSRF attack: expected #{ session[:_csrf_token] }, was #{ params[:_csrf_token] }"
      # manual handling
    end
  end
end
```

#### Bypass Security Check

```ruby
module Web::Controllers::Books
  class Create
    include Web::Action

    def call(params)
      # ...
    end

    private

    def verify_csrf_token?
      false
    end
  end
end
```

Closes #247 