### PR TITLE
Fix option at path when we mount lotus application apps inside container

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 
 gem 'lotus-utils',       '~> 0.4', require: false, github: 'lotus/utils',       branch: '0.4.x'
 gem 'lotus-validations', '~> 0.3', require: false, github: 'lotus/validations', branch: '0.3.x'
-gem 'lotus-router',      '~> 0.4', require: false, github: 'lotus/router',      branch: '0.4.x'
+gem 'lotus-router',      '~> 0.4', require: false, github: 'lotus/router',      branch: 'master'
 gem 'lotus-controller',  '~> 0.4', require: false, github: 'lotus/controller',  branch: '0.4.x'
 gem 'lotus-view',        '~> 0.4', require: false, github: 'lotus/view',        branch: '0.4.x'
 gem 'lotus-model',       '~> 0.3', require: false, github: 'lotus/model',       branch: '0.3.x'

--- a/lib/lotus/application.rb
+++ b/lib/lotus/application.rb
@@ -105,8 +105,8 @@ module Lotus
     # @return [Lotus::Application] a new instance of the application
     #
     # @since 0.1.0
-    def initialize(path_prefix: path_prefix)
-      self.class.configuration.path_prefix path_prefix
+    def initialize(options = {})
+      self.class.configuration.path_prefix options[:path_prefix]
       self.class.load!(self)
     end
 

--- a/lib/lotus/application.rb
+++ b/lib/lotus/application.rb
@@ -105,7 +105,8 @@ module Lotus
     # @return [Lotus::Application] a new instance of the application
     #
     # @since 0.1.0
-    def initialize
+    def initialize(path_prefix: path_prefix)
+      self.class.configuration.path_prefix path_prefix
       self.class.load!(self)
     end
 

--- a/lib/lotus/configuration.rb
+++ b/lib/lotus/configuration.rb
@@ -1627,6 +1627,20 @@ module Lotus
       @view ||= Config::FrameworkConfiguration.new
     end
 
+    # This options is used as a bridge between container and router application.
+    #
+    # @return [String, NilClass] path prefix for routes
+    #
+    # @since x.x.x
+    # @api private
+    def path_prefix(value = nil)
+      if value.nil?
+        @path_prefix
+      else
+        @path_prefix = value
+      end
+    end
+
     private
     # @since 0.2.0
     # @api private

--- a/lib/lotus/container.rb
+++ b/lib/lotus/container.rb
@@ -3,6 +3,21 @@ require 'lotus/router'
 
 module Lotus
   class Container
+    class Router < ::Lotus::Router
+      def mount(app, options)
+        if lotus_app?(app)
+          app = app.new(path_prefix: options.fetch(:at))
+        end
+        super(app, options)
+      end
+
+      private
+
+      def lotus_app?(app)
+        app.ancestors.include? Lotus::Application
+      end
+    end
+
     attr_reader :routes
 
     def self.configure(&blk)
@@ -12,7 +27,7 @@ module Lotus
     def initialize
       Mutex.new.synchronize do
         assert_configuration_presence!
-        @routes = Lotus::Router.new(&@@configuration)
+        @routes = Router.new(&@@configuration)
       end
     end
 

--- a/lib/lotus/loader.rb
+++ b/lib/lotus/loader.rb
@@ -190,6 +190,7 @@ module Lotus
         scheme:      configuration.scheme,
         host:        configuration.host,
         port:        configuration.port,
+        prefix:      configuration.path_prefix,
         &configuration.routes
       )
     end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -154,3 +154,23 @@ class DisabledCSRFAction
     false
   end
 end
+
+module Admin
+  class Application < Lotus::Application
+    configure do
+      routes do
+        get '/home', to: 'home#index', as: :home
+      end
+    end
+  end
+end
+
+module CallCenter
+  class Application < Lotus::Application
+    configure do
+      routes do
+        get '/home', to: 'home#index', as: :home
+      end
+    end
+  end
+end

--- a/test/integration/container_test.rb
+++ b/test/integration/container_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+describe Lotus::Container do
+  describe 'apps mounted with container' do
+    it 'should generate correct paths with route helper' do
+      Lotus::Container.configure do
+        mount Admin::Application, at: '/admin'
+        mount CallCenter::Application, at: '/callcenter'
+      end
+
+      Lotus::Container.new
+
+      CallCenter::Routes.path(:home).must_equal '/callcenter/home'
+      Admin::Routes.path(:home).must_equal '/admin/home'
+    end
+  end
+end


### PR DESCRIPTION
# Problem
There is a problem when we mount applications inside lotus apps and we want generate urls or paths with routes helpers
```ruby
require 'lotus'

module Admin
  class Application < Lotus::Application
    configure do
      routes do
        get '/home', to: 'home#index', as: :home
      end
    end
  end
end

module CallCenter
  class Application < Lotus::Application
    configure do
      routes do
        get '/home', to: 'home#index', as: :home
      end
    end
  end
end

Lotus::Container.configure do
  mount Admin::Application, at: '/admin'
  mount CallCenter::Application, at: '/callcenter'
end

Lotus::Container.new

CallCenter::Routes.path(:home) # => '/home' WRONG
Admin::Routes.path(:home) # => '/home' WRONG
```
# Solution
Now with this PR fixes this problem

```ruby
require 'lotus'

module Admin
  class Application < Lotus::Application
    configure do
      routes do
        get '/home', to: 'home#index', as: :home
      end
    end
  end
end

module CallCenter
  class Application < Lotus::Application
    configure do
      routes do
        get '/home', to: 'home#index', as: :home
      end
    end
  end
end

Lotus::Container.configure do
  mount Admin::Application, at: '/admin'
  mount CallCenter::Application, at: '/callcenter'
end

Lotus::Container.new

CallCenter::Routes.path(:home) # => '/callcenter/home' GOOD
Admin::Routes.path(:home) # => '/admin/home' GOOD
```