### PR TITLE
Database migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'lotus-validations', '~> 0.3', require: false, github: 'lotus/validations', 
 gem 'lotus-router',      '~> 0.4', require: false, github: 'lotus/router',      branch: '0.4.x'
 gem 'lotus-controller',  '~> 0.4', require: false, github: 'lotus/controller',  branch: '0.4.x'
 gem 'lotus-view',        '~> 0.4', require: false, github: 'lotus/view',        branch: '0.4.x'
-gem 'lotus-model',       '~> 0.3', require: false, github: 'lotus/model',       branch: '0.3.x'
+gem 'lotus-model',       '~> 0.3', require: false, github: 'lotus/model',       branch: 'database-migrations'
 gem 'lotus-helpers',     '~> 0.2', require: false, github: 'lotus/helpers',     branch: '0.2.x'
 
 platforms :ruby do

--- a/lib/lotus/cli.rb
+++ b/lib/lotus/cli.rb
@@ -79,7 +79,7 @@ module Lotus
       end
     end
 
-    desc 'generate', 'generates a new action'
+    desc 'generate', 'generates action, model or migration'
     method_option :application_base_url, desc: 'application base url',     type: :string
     method_option :path,                desc: 'applications path',                                         type: :string,  default: 'apps'
     method_option :skip_view,           desc: 'skip the creation of view and templates (only for action)', type: :boolean, default: false

--- a/lib/lotus/commands/console.rb
+++ b/lib/lotus/commands/console.rb
@@ -24,7 +24,7 @@ module Lotus
       def start
         # Clear out ARGV so Pry/IRB don't attempt to parse the rest
         ARGV.shift until ARGV.empty?
-        require @environment.env_config.to_s
+        @environment.require_application_environment
 
         # Add convenience methods to the main:Object binding
         TOPLEVEL_BINDING.eval('self').send(:include, Methods)

--- a/lib/lotus/commands/db.rb
+++ b/lib/lotus/commands/db.rb
@@ -70,7 +70,7 @@ module Lotus
         if options[:help]
           invoke :help, ['apply']
         else
-          assert_allowed_environment!([:test, :production])
+          assert_development_environment!
           require 'lotus/commands/db/apply'
           Lotus::Commands::DB::Apply.new(environment).start
         end
@@ -91,15 +91,36 @@ module Lotus
         end
       end
 
+      desc 'db version', 'database version'
+
+      desc 'version', 'current database version'
+      method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+
+      def version
+        if options[:help]
+          invoke :help, ['version']
+        else
+          require 'lotus/commands/db/version'
+          Lotus::Commands::DB::Version.new(environment).start
+        end
+      end
+
       private
 
       def environment
         Lotus::Environment.new(options)
       end
 
-      def assert_allowed_environment!(env = :production)
-        if environment.environment?(*env)
+      def assert_allowed_environment!
+        if environment.environment?(:production)
           puts "Can't run this command in production mode"
+          exit 1
+        end
+      end
+
+      def assert_development_environment!
+        unless environment.environment?(:development)
+          puts "This command can be ran only in development mode"
           exit 1
         end
       end

--- a/lib/lotus/commands/db.rb
+++ b/lib/lotus/commands/db.rb
@@ -17,10 +17,91 @@ module Lotus
         end
       end
 
+      desc 'db create', 'create database'
+
+      desc 'create', 'create database for current environment'
+      method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+
+      def create
+        if options[:help]
+          invoke :help, ['create']
+        else
+          assert_allowed_environment!
+          require 'lotus/commands/db/create'
+          Lotus::Commands::DB::Create.new(environment).start
+        end
+      end
+
+      desc 'db drop', 'create database'
+
+      desc 'drop', 'drop database for current environment'
+      method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+
+      def drop
+        if options[:help]
+          invoke :help, ['drop']
+        else
+          assert_allowed_environment!
+          require 'lotus/commands/db/drop'
+          Lotus::Commands::DB::Drop.new(environment).start
+        end
+      end
+
+      desc 'db migrate', 'migrate database'
+
+      desc 'migrate', 'migrate database for current environment'
+      method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+
+      def migrate(version = nil)
+        if options[:help]
+          invoke :help, ['migrate']
+        else
+          require 'lotus/commands/db/migrate'
+          Lotus::Commands::DB::Migrate.new(environment, version).start
+        end
+      end
+
+      desc 'db apply', 'apply database changes'
+
+      desc 'apply', 'migrate, dump schema, delete migrations (experimental)'
+      method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+
+      def apply
+        if options[:help]
+          invoke :help, ['apply']
+        else
+          assert_allowed_environment!([:test, :production])
+          require 'lotus/commands/db/apply'
+          Lotus::Commands::DB::Apply.new(environment).start
+        end
+      end
+
+      desc 'db prepare', 'prepare database'
+
+      desc 'prepare', 'create and migrate database'
+      method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
+
+      def prepare
+        if options[:help]
+          invoke :help, ['prepare']
+        else
+          assert_allowed_environment!
+          require 'lotus/commands/db/prepare'
+          Lotus::Commands::DB::Prepare.new(environment).start
+        end
+      end
+
       private
 
       def environment
         Lotus::Environment.new(options)
+      end
+
+      def assert_allowed_environment!(env = :production)
+        if environment.environment?(*env)
+          puts "Can't run this command in production mode"
+          exit 1
+        end
       end
     end
   end

--- a/lib/lotus/commands/db.rb
+++ b/lib/lotus/commands/db.rb
@@ -32,7 +32,7 @@ module Lotus
         end
       end
 
-      desc 'db drop', 'create database'
+      desc 'db drop', 'drop database'
 
       desc 'drop', 'drop database for current environment'
       method_option :environment, desc: 'path to environment configuration (config/environment.rb)'

--- a/lib/lotus/commands/db/abstract.rb
+++ b/lib/lotus/commands/db/abstract.rb
@@ -1,0 +1,15 @@
+module Lotus
+  module Commands
+    class DB
+      class Abstract
+        def initialize(environment)
+          environment.require_application_environment
+        end
+
+        def start
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/commands/db/apply.rb
+++ b/lib/lotus/commands/db/apply.rb
@@ -1,0 +1,14 @@
+require 'lotus/commands/db/abstract'
+
+module Lotus
+  module Commands
+    class DB
+      class Apply < Abstract
+        def start
+          require 'lotus/model/migrator'
+          Lotus::Model::Migrator.apply
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/commands/db/console.rb
+++ b/lib/lotus/commands/db/console.rb
@@ -10,7 +10,7 @@ module Lotus
           @name        = name
           @environment = environment
           @env_options = environment.to_options
-          load_config
+          @environment.require_application_environment
         end
 
         def start
@@ -43,10 +43,6 @@ module Lotus
 
         def connection_string
           adapter_class.new(mapper, adapter_config.uri).connection_string
-        end
-
-        def load_config
-          require @env_options[:env_config]
         end
       end
     end

--- a/lib/lotus/commands/db/create.rb
+++ b/lib/lotus/commands/db/create.rb
@@ -1,0 +1,14 @@
+require 'lotus/commands/db/abstract'
+
+module Lotus
+  module Commands
+    class DB
+      class Create < Abstract
+        def start
+          require 'lotus/model/migrator'
+          Lotus::Model::Migrator.create
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/commands/db/drop.rb
+++ b/lib/lotus/commands/db/drop.rb
@@ -1,0 +1,14 @@
+require 'lotus/commands/db/abstract'
+
+module Lotus
+  module Commands
+    class DB
+      class Drop < Abstract
+        def start
+          require 'lotus/model/migrator'
+          Lotus::Model::Migrator.drop
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/commands/db/migrate.rb
+++ b/lib/lotus/commands/db/migrate.rb
@@ -1,0 +1,19 @@
+require 'lotus/commands/db/abstract'
+
+module Lotus
+  module Commands
+    class DB
+      class Migrate < Abstract
+        def initialize(environment, version)
+          super(environment)
+          @version = version
+        end
+
+        def start
+          require 'lotus/model/migrator'
+          Lotus::Model::Migrator.migrate(version: @version)
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/commands/db/prepare.rb
+++ b/lib/lotus/commands/db/prepare.rb
@@ -1,0 +1,14 @@
+require 'lotus/commands/db/abstract'
+
+module Lotus
+  module Commands
+    class DB
+      class Prepare < Abstract
+        def start
+          require 'lotus/model/migrator'
+          Lotus::Model::Migrator.prepare
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/commands/db/version.rb
+++ b/lib/lotus/commands/db/version.rb
@@ -1,0 +1,14 @@
+require 'lotus/commands/db/abstract'
+
+module Lotus
+  module Commands
+    class DB
+      class Version < Abstract
+        def start
+          require 'lotus/model/migrator'
+          puts Lotus::Model::Migrator.version
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/commands/generate.rb
+++ b/lib/lotus/commands/generate.rb
@@ -20,12 +20,13 @@ module Lotus
 
       # @since 0.3.0
       # @api private
-      attr_reader :cli, :source, :target, :app, :app_name, :name, :options
+      attr_reader :cli, :source, :target, :app, :app_name, :name, :options, :env
 
       # @since 0.3.0
       # @api private
       def initialize(type, app_name, name, env, cli)
         @cli      = cli
+        @env      = env
         @name     = name
 
         @type = sanitize_type(type)

--- a/lib/lotus/commands/routes.rb
+++ b/lib/lotus/commands/routes.rb
@@ -2,11 +2,10 @@ module Lotus
   module Commands
     class Routes
       def initialize(environment)
-        @environment = environment
+        environment.require_application_environment
       end
 
       def start
-        require @environment.env_config
         puts Lotus::Container.new.routes.inspector.to_s
       end
     end

--- a/lib/lotus/environment.rb
+++ b/lib/lotus/environment.rb
@@ -315,6 +315,16 @@ module Lotus
       root.join(@options.fetch(:environment) { config.join(DEFAULT_ENVIRONMENT_CONFIG) })
     end
 
+    # Require application environment
+    #
+    # Eg <tt>require "config/environment"</tt>.
+    #
+    # @since x.x.x
+    # @api private
+    def require_application_environment
+      require env_config.to_s
+    end
+
     # Determine if activate code reloading for the current environment while
     # running the server.
     #

--- a/lib/lotus/generators/application/container.rb
+++ b/lib/lotus/generators/application/container.rb
@@ -46,7 +46,7 @@ module Lotus
             "lib/#{ app_name }/repositories"
           ]
 
-          empty_directories << if database_type == :sql
+          empty_directories << if sql_database?
             "db/migrations"
           else
             "db"
@@ -69,7 +69,7 @@ module Lotus
             )
           end
 
-          if database_type == :sql
+          if sql_database?
             templates.merge!(
               'schema.sql.tt' => 'db/schema.sql'
             )
@@ -132,6 +132,10 @@ module Lotus
           when 'memory'
             :memory
           end
+        end
+
+        def sql_database?
+          database_type == :sql
         end
 
         def database_uri

--- a/lib/lotus/generators/application/container.rb
+++ b/lib/lotus/generators/application/container.rb
@@ -42,10 +42,15 @@ module Lotus
           }
 
           empty_directories = [
-            "db",
             "lib/#{ app_name }/entities",
             "lib/#{ app_name }/repositories"
           ]
+
+          empty_directories << if database_type == :sql
+            "db/migrations"
+          else
+            "db"
+          end
 
           case options[:test]
           when 'rspec'
@@ -61,6 +66,12 @@ module Lotus
               'Rakefile.minitest.tt'           => 'Rakefile',
               'spec_helper.rb.minitest.tt'     => 'spec/spec_helper.rb',
               'features_helper.rb.minitest.tt' => 'spec/features_helper.rb'
+            )
+          end
+
+          if database_type == :sql
+            templates.merge!(
+              'schema.sql.tt' => 'db/schema.sql'
             )
           end
 

--- a/lib/lotus/generators/application/container/lib/app_name.rb.tt
+++ b/lib/lotus/generators/application/container/lib/app_name.rb.tt
@@ -2,6 +2,7 @@ require 'lotus/model'
 Dir["#{ __dir__ }/<%= config[:app_name] %>/**/*.rb"].each { |file| require_relative file }
 
 Lotus::Model.configure do
+  ##
   # Database adapter
   #
   # Available options:
@@ -16,6 +17,14 @@ Lotus::Model.configure do
   #
   adapter type: :<%= config[:database_config][:type] %>, uri: ENV['<%= config[:app_name].to_env_s %>_DATABASE_URL']
 
+  <%- if config[:database_config][:type] == :sql -%>
+  ##
+  # Migrations
+  #
+  migrations 'db/migrations'
+  schema     'db/schema.sql'
+
+  <%- end -%>
   ##
   # Database mapping
   #

--- a/lib/lotus/generators/migration.rb
+++ b/lib/lotus/generators/migration.rb
@@ -29,7 +29,7 @@ module Lotus
         name        = Utils::String.new(app_name).underscore
         filename    = FILENAME % { timestamp: timestamp, name: name }
 
-        require env.env_config # require "config/environment.rb" from application
+        env.require_application_environment
         @destination = Lotus::Model.configuration.migrations.join(filename)
 
         cli.class.source_root(source)

--- a/lib/lotus/generators/migration.rb
+++ b/lib/lotus/generators/migration.rb
@@ -1,0 +1,51 @@
+require 'lotus/generators/abstract'
+require 'lotus/utils/string'
+
+module Lotus
+  module Generators
+    # @since x.x.x
+    # @api private
+    class Migration < Abstract
+      # @since x.x.x
+      # @api private
+      #
+      # @example
+      #   20150612160502
+      TIMESTAMP_FORMAT = '%Y%m%d%H%M%S'.freeze
+
+      # @since x.x.x
+      # @api private
+      #
+      # @example
+      #   20150612160502_create_books.rb
+      FILENAME = '%{timestamp}_%{name}.rb'.freeze
+
+      # @since x.x.x
+      # @api private
+      def initialize(command)
+        super
+
+        timestamp   = Time.now.utc.strftime(TIMESTAMP_FORMAT)
+        name        = Utils::String.new(app_name).underscore
+        filename    = FILENAME % { timestamp: timestamp, name: name }
+
+        require env.env_config # require "config/environment.rb" from application
+        @destination = Lotus::Model.configuration.migrations.join(filename)
+
+        cli.class.source_root(source)
+      end
+
+      # @since x.x.x
+      # @api private
+      def start
+        templates = {
+          'migration.rb.tt' => @destination
+        }
+
+        templates.each do |src, dst|
+          cli.template(source.join(src), target.join(dst), {})
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/generators/migration/migration.rb.tt
+++ b/lib/lotus/generators/migration/migration.rb.tt
@@ -1,0 +1,4 @@
+Lotus::Model.migration do
+  change do
+  end
+end

--- a/test/commands/new_test.rb
+++ b/test/commands/new_test.rb
@@ -447,6 +447,8 @@ describe Lotus::Commands::New do
           it 'generates adapter config for mysql' do
             content = @root.join('lib/chirp.rb').read
             content.must_match %(adapter type: :sql, uri: ENV['CHIRP_DATABASE_URL'])
+            content.must_match %(migrations 'db/migrations')
+            content.must_match %(schema     'db/schema.sql')
           end
         end
 
@@ -455,6 +457,8 @@ describe Lotus::Commands::New do
           it 'generates adapter config for mysql2' do
             content = @root.join('lib/chirp.rb').read
             content.must_match %(adapter type: :sql, uri: ENV['CHIRP_DATABASE_URL'])
+            content.must_match %(migrations 'db/migrations')
+            content.must_match %(schema     'db/schema.sql')
           end
         end
 
@@ -463,6 +467,8 @@ describe Lotus::Commands::New do
           it 'generates adapter config for postgresql' do
             content = @root.join('lib/chirp.rb').read
             content.must_match %(adapter type: :sql, uri: ENV['CHIRP_DATABASE_URL'])
+            content.must_match %(migrations 'db/migrations')
+            content.must_match %(schema     'db/schema.sql')
           end
         end
 
@@ -472,6 +478,8 @@ describe Lotus::Commands::New do
           it 'generates adapter config for postgres' do
             content = @root.join('lib/chirp.rb').read
             content.must_match %(adapter type: :sql, uri: ENV['CHIRP_DATABASE_URL'])
+            content.must_match %(migrations 'db/migrations')
+            content.must_match %(schema     'db/schema.sql')
           end
         end
 
@@ -481,6 +489,8 @@ describe Lotus::Commands::New do
           it 'generates adapter config for sqlite' do
             content = @root.join('lib/chirp.rb').read
             content.must_match %(adapter type: :sql, uri: ENV['CHIRP_DATABASE_URL'])
+            content.must_match %(migrations 'db/migrations')
+            content.must_match %(schema     'db/schema.sql')
           end
         end
 
@@ -489,6 +499,8 @@ describe Lotus::Commands::New do
           it 'generates adapter config for sqlite3' do
             content = @root.join('lib/chirp.rb').read
             content.must_match %(adapter type: :sql, uri: ENV['CHIRP_DATABASE_URL'])
+            content.must_match %(migrations 'db/migrations')
+            content.must_match %(schema     'db/schema.sql')
           end
         end
 
@@ -497,6 +509,8 @@ describe Lotus::Commands::New do
           it 'generates adapter config for memory' do
             content = @root.join('lib/chirp.rb').read
             content.must_match %(adapter type: :memory, uri: ENV['CHIRP_DATABASE_URL'])
+            content.wont_match %(migrations 'db/migrations')
+            content.wont_match %(schema     'db/schema.sql')
           end
         end
       end
@@ -516,7 +530,26 @@ describe Lotus::Commands::New do
 
     describe 'db' do
       it 'generates it' do
-        @root.join('db').must_be :directory?
+        @root.join('db').must_be            :directory?
+        @root.join('db/migrations').wont_be :exist?
+      end
+
+      ['postgres', 'postgresql', 'mysql', 'mysql2', 'sqlite', 'sqlite3'].each do |database|
+        describe "with #{ database }" do
+          let(:opts) { container_options.merge(database: database) }
+
+          it "generates 'db/migrations'" do
+            @root.join('db/migrations').must_be          :directory?
+            @root.join('db/migrations/.gitkeep').must_be :exist?
+
+            @root.join('db/.gitkeep').wont_be :exist?
+          end
+
+          it "generates empty 'db/schema.sql'" do
+            @root.join('db/schema.sql').must_be      :exist?
+            @root.join('db/schema.sql').read.must_be :empty?
+          end
+        end
       end
     end
 

--- a/test/integration/cli/database_test.rb
+++ b/test/integration/cli/database_test.rb
@@ -1,0 +1,358 @@
+require 'test_helper'
+require 'sequel'
+
+describe 'lotus db' do
+  def create_temporary_dir
+    @tmp = Pathname.new(@pwd = Dir.pwd).join('tmp/integration/cli/database')
+    @tmp.rmtree if @tmp.exist?
+    @tmp.mkpath
+
+    Dir.chdir(@tmp)
+  end
+
+  def generate_application
+    `bundle exec lotus new #{ @app_name = 'delivery' } --database=sqlite3`
+    Dir.chdir(@root = @tmp.join(@app_name))
+
+    File.open(@root.join('.env.development'), 'w') do |f|
+      f.write <<-DOTENV
+#{ @app_name.upcase }_DATABASE_URL="sqlite://#{ @root.join("db/#{ @app_name }_development.sqlite3") }"
+      DOTENV
+    end
+
+    File.open(@root.join('.env.test'), 'w') do |f|
+      f.write <<-DOTENV
+#{ @app_name.upcase }_DATABASE_URL="sqlite://#{ @root.join("db/#{ @app_name }_test.sqlite3") }"
+      DOTENV
+    end
+
+    File.open(@root.join('.env'), 'w') do |f|
+      f.write <<-DOTENV
+#{ @app_name.upcase }_DATABASE_URL="sqlite://#{ @root.join("db/#{ @app_name }.sqlite3") }"
+      DOTENV
+    end
+
+    File.open(@root.join('db/migrations/20150613152241_create_users.rb'), 'w') do |f|
+      f.write <<-MIGRATION
+Lotus::Model.migration do
+  change do
+    create_table :users do
+      primary_key :id
+      column :email, String
+    end
+  end
+end
+MIGRATION
+    end
+
+    File.open(@root.join('db/migrations/20150613152815_add_name_to_users.rb'), 'w') do |f|
+      f.write <<-MIGRATION
+Lotus::Model.migration do
+  change do
+    alter_table :users do
+      add_column :name, String
+    end
+  end
+end
+MIGRATION
+    end
+
+  end
+
+  def db_create
+    `LOTUS_ENV="#{ lotus_env }" bundle exec lotus db create`
+  end
+
+  def db_drop
+    `LOTUS_ENV="#{ lotus_env }" bundle exec lotus db drop`
+  end
+
+  def db_migrate(version = nil)
+    `LOTUS_ENV="#{ lotus_env }" bundle exec lotus db migrate #{ version }`
+  end
+
+  def db_apply
+    `LOTUS_ENV="#{ lotus_env }" bundle exec lotus db apply`
+  end
+
+  def db_prepare
+    `LOTUS_ENV="#{ lotus_env }" bundle exec lotus db prepare`
+  end
+
+  def chdir_to_root
+    Dir.chdir($pwd)
+  end
+
+  before do
+    create_temporary_dir
+    generate_application
+  end
+
+  let(:lotus_env) { 'development' }
+
+  describe 'create' do
+    before do
+      db_create
+    end
+
+    describe 'default environment' do
+      it 'creates database' do
+        @root.join("db/#{ @app_name }_development.sqlite3").must_be :exist?
+      end
+    end
+
+    describe 'test environment' do
+      let(:lotus_env) { 'test' }
+
+      it 'creates database' do
+        @root.join("db/#{ @app_name }_test.sqlite3").must_be :exist?
+      end
+    end
+
+    describe 'production environment' do
+      let(:lotus_env) { 'production' }
+
+      it "doesn't create database" do
+        @root.join("db/#{ @app_name }.sqlite3").wont_be :exist?
+      end
+    end
+  end
+
+  describe 'drop' do
+    before do
+      # simulate pre-existing production database
+      FileUtils.touch @root.join("db/#{ @app_name }.sqlite3")
+
+      db_create
+      db_drop
+    end
+
+    describe 'default environment' do
+      it 'drops database' do
+        @root.join("db/#{ @app_name }_development.sqlite3").wont_be :exist?
+      end
+    end
+
+    describe 'test environment' do
+      let(:lotus_env) { 'test' }
+
+      it 'drops database' do
+        @root.join("db/#{ @app_name }_test.sqlite3").wont_be :exist?
+      end
+    end
+
+    describe 'production environment' do
+      let(:lotus_env) { 'production' }
+
+      it "doesn't drop database" do
+        @root.join("db/#{ @app_name }.sqlite3").must_be :exist?
+      end
+    end
+  end
+
+  describe 'migrate' do
+    before do
+      db_create
+      db_migrate
+    end
+
+    describe 'default environment' do
+      it 'migrates database' do
+        database   = @root.join("db/#{ @app_name }_development.sqlite3")
+        connection = Sequel.connect("sqlite://#{ database }")
+        version    = connection[:schema_migrations].to_a.last
+
+        version.fetch(:filename).must_equal '20150613152815_add_name_to_users.rb'
+      end
+    end
+
+    describe 'test environment' do
+      let(:lotus_env) { 'test' }
+
+      it 'migrates database' do
+        database   = @root.join("db/#{ @app_name }_test.sqlite3")
+        connection = Sequel.connect("sqlite://#{ database }")
+        version    = connection[:schema_migrations].to_a.last
+
+        version.fetch(:filename).must_equal '20150613152815_add_name_to_users.rb'
+      end
+    end
+
+    describe 'production environment' do
+      let(:lotus_env) { 'production' }
+
+      it 'migrates database'
+      # it 'migrates database' do
+      #   database   = @root.join("db/#{ @app_name }.sqlite3")
+      #   connection = Sequel.connect("sqlite://#{ database }")
+      #   version    = connection[:schema_migrations].to_a.last
+
+      #   version.fetch(:filename).must_equal '20150613152815_add_name_to_users.rb'
+      # end
+    end
+  end
+
+  describe 'migrate with version' do
+    before do
+      db_create
+      db_migrate
+      db_migrate "20150613152241"
+    end
+
+    describe 'default environment' do
+      it 'migrates database' do
+        database   = @root.join("db/#{ @app_name }_development.sqlite3")
+        connection = Sequel.connect("sqlite://#{ database }")
+        version    = connection[:schema_migrations].to_a.last
+
+        version.fetch(:filename).must_equal '20150613152241_create_users.rb'
+      end
+    end
+
+    describe 'test environment' do
+      let(:lotus_env) { 'test' }
+
+      it 'migrates database' do
+        database   = @root.join("db/#{ @app_name }_test.sqlite3")
+        connection = Sequel.connect("sqlite://#{ database }")
+        version    = connection[:schema_migrations].to_a.last
+
+        version.fetch(:filename).must_equal '20150613152241_create_users.rb'
+      end
+    end
+
+    describe 'production environment' do
+      let(:lotus_env) { 'production' }
+
+      it 'migrates database'
+      # it 'migrates database' do
+      #   database   = @root.join("db/#{ @app_name }.sqlite3")
+      #   connection = Sequel.connect("sqlite://#{ database }")
+      #   version    = connection[:schema_migrations].to_a.last
+
+      #   version.fetch(:filename).must_equal '20150613152241_create_users.rb'
+      # end
+    end
+  end
+
+  describe 'apply' do
+    before do
+      @root.join("db/schema.sql").delete
+
+      db_create
+      db_apply
+    end
+
+    describe 'default environment' do
+      it 'migrates database' do
+        database   = @root.join("db/#{ @app_name }_development.sqlite3")
+        connection = Sequel.connect("sqlite://#{ database }")
+        version    = connection[:schema_migrations].to_a.last
+
+        version.fetch(:filename).must_equal '20150613152815_add_name_to_users.rb'
+      end
+
+      it 'generates schema.sql' do
+        @root.join("db/schema.sql").must_be :exist?
+      end
+
+      it 'deletes migrations' do
+        @root.join("db/migrations").children.must_be :empty?
+      end
+    end
+
+    describe 'test environment' do
+      let(:lotus_env) { 'test' }
+
+      it "doesn't migrate database" do
+        database   = @root.join("db/#{ @app_name }_test.sqlite3")
+        connection = Sequel.connect("sqlite://#{ database }")
+
+        connection.tables.must_be :empty?
+      end
+
+      it "doesn't generate schema.sql" do
+        @root.join("db/schema.sql").wont_be :exist?
+      end
+
+      it "doesn't delete migrations" do
+        @root.join("db/migrations").children.wont_be :empty?
+      end
+    end
+
+    describe 'production environment' do
+      let(:lotus_env) { 'production' }
+
+      it "doesn't migrate database" do
+        database   = @root.join("db/#{ @app_name }.sqlite3")
+        connection = Sequel.connect("sqlite://#{ database }")
+
+        connection.tables.must_be :empty?
+      end
+
+      it "doesn't generate schema.sql" do
+        @root.join("db/schema.sql").wont_be :exist?
+      end
+
+      it "doesn't delete migrations" do
+        @root.join("db/migrations").children.wont_be :empty?
+      end
+    end
+  end
+
+  describe 'prepare' do
+    before do
+      db_create
+      db_apply
+      db_drop
+
+      File.open(@root.join('db/migrations/20150613154832_create_deliveries.rb'), 'w') do |f|
+        f.write <<-MIGRATION
+Lotus::Model.migration do
+  change do
+    create_table :deliveries do
+      primary_key :id
+      foreign_key :user_id, :users
+    end
+  end
+end
+MIGRATION
+      end
+
+      db_prepare
+    end
+
+    describe 'default environment' do
+      it 'creates and migrates database' do
+        database   = @root.join("db/#{ @app_name }_development.sqlite3")
+        connection = Sequel.connect("sqlite://#{ database }")
+        version    = connection[:schema_migrations].to_a.last
+
+        version.fetch(:filename).must_equal '20150613154832_create_deliveries.rb'
+      end
+    end
+
+    describe 'test environment' do
+      let(:lotus_env) { 'test' }
+
+      it 'creates and migrates database' do
+        database   = @root.join("db/#{ @app_name }_test.sqlite3")
+        connection = Sequel.connect("sqlite://#{ database }")
+        version    = connection[:schema_migrations].to_a.last
+
+        version.fetch(:filename).must_equal '20150613154832_create_deliveries.rb'
+      end
+    end
+
+    describe 'production environment' do
+      let(:lotus_env) { 'production' }
+
+      it "doesn't create database" do
+        database   = @root.join("db/#{ @app_name }.sqlite3")
+        connection = Sequel.connect("sqlite://#{ database }")
+
+        connection.tables.must_be :empty?
+      end
+    end
+  end
+end

--- a/test/integration/cli/database_test.rb
+++ b/test/integration/cli/database_test.rb
@@ -79,6 +79,10 @@ MIGRATION
     `LOTUS_ENV="#{ lotus_env }" bundle exec lotus db prepare`
   end
 
+  def db_version
+    `LOTUS_ENV="#{ lotus_env }" bundle exec lotus db version`
+  end
+
   def chdir_to_root
     Dir.chdir($pwd)
   end
@@ -86,6 +90,10 @@ MIGRATION
   before do
     create_temporary_dir
     generate_application
+  end
+
+  after do
+    chdir_to_root
   end
 
   let(:lotus_env) { 'development' }
@@ -353,6 +361,42 @@ MIGRATION
 
         connection.tables.must_be :empty?
       end
+    end
+  end
+
+  describe 'version' do
+    before do
+      db_create
+      db_migrate
+    end
+
+    describe 'default environment' do
+      it 'prints current database version' do
+        out = db_version
+
+        out.must_equal "20150613152815\n"
+      end
+    end
+
+    describe 'test environment' do
+      let(:lotus_env) { 'test' }
+
+      it 'prints current database version' do
+        out = db_version
+
+        out.must_equal "20150613152815\n"
+      end
+    end
+
+    describe 'production environment' do
+      let(:lotus_env) { 'production' }
+
+      it 'prints current database version'
+      # it 'prints current database version' do
+      #   out = db_version
+
+      #   out.must_equal "20150613152815\n"
+      # end
     end
   end
 end

--- a/test/integration/cli/generate_test.rb
+++ b/test/integration/cli/generate_test.rb
@@ -8,6 +8,7 @@ describe 'lotus generate' do
     let(:template_engine)   { 'erb' }
     let(:framework_testing) { 'minitest' }
     let(:klass)             { 'test' }
+    let(:migration_name)    { 'create_books' }
 
     def create_temporary_dir
       @tmp = Pathname.new(@pwd = Dir.pwd).join('tmp/integration/cli/generate')
@@ -50,12 +51,16 @@ template=#{ template_engine }
       `bundle exec lotus generate model #{ klass }`
     end
 
+    def generate_migration
+      `bundle exec lotus generate migration #{ migration_name }`
+    end
+
     def generate_container
       `bundle exec lotus generate app #{ new_app_name } #{ new_options }`
     end
 
     def chdir_to_root
-      Dir.chdir(@pwd)
+      Dir.chdir($pwd)
     end
 
     before do
@@ -133,6 +138,19 @@ template=#{ template_engine }
           @root.join('spec/delivery/entities/test_case_spec.rb').must_be                :exist?
           @root.join('spec/delivery/repositories/test_case_repository_spec.rb').must_be :exist?
         end
+      end
+    end
+
+    describe 'when application generates new migration' do
+      let(:options) { ' --database=sqlite3' }
+
+      before do
+        generate_migration
+      end
+
+      it 'generates it' do
+        migration = @root.join('db/migrations').children.last
+        migration.basename.to_s.must_match(/\A[\d]{14}\_create\_books\.rb\z/)
       end
     end
 


### PR DESCRIPTION
Introduce new CLI facilities for database migrations.

## New Applications

When a new application is generates via `lotus new`, if the specified `--database=` option is a SQL database (postgres, sqlite, mysql), it:

  * Creates empty `db/migrations` directory
  * Creates empty `db/schema.sql` file
  * Adds `migrations "db/migrations"` setting to `lib/bookshelf.rb`
  * Adds `schema "db/schema.sql"` setting to `lib/bookshelf.rb`

Example:

```shell
lotus new bookshelf --database=postgres
```

```ruby
# lib/bookshelf.rb
# ...
Lotus::Model.configure do
  # ...
  migrations 'db/migrations'
  schema    'db/schema.sql'
end
```

## Migration Generator

New generator for timestamp migration:

```shell
bundle exec lotus generate migration create_books
      create  db/migrations/20150613165259_create_books.rb
```

### CLI commands

#### Create

Creates database for the current environment. For data integrity reasons it's not allowed in production.

```shell
bundle exec lotus db create
```

#### Drop

Drops database for the current environment. For data integrity reasons it's not allowed in production.

```shell
bundle exec lotus db drop
```

#### Migrate

Migrate database.
It accepts an optional argument for a target version

```shell
% tree db/migrations
db/migrations
├── 20150613165259_create_books.rb
└── 20150613165900_create_authors.rb

% bundle exec lotus db migrate # Migrates to max migration (20150613165900)
% bundle exec lotus db migrate 20150613165259 # Migrates (down) to 20150613165900
```

#### Apply

This is an **experimental feature**.
When an application is developed after years, it accumulates dozens or hundreds of migrations, this slows down  database operations for development and tests (CI).

Because it does destructive changes for files under SCM, this is only allowed in development mode.

When we run `db apply` it:

  * Runs pending migrations
  * Dumps a fresh schema into `db/schema.sql`
  * Deletes all the migrations from `db/migrations`

```shell
bundle exec lotus db apply
``` 

See next section.

#### Prepare

Prepares database for the current environment. It's only allowed in development and test mode.

When we run `db prepare` it:

  * Creates database
  * Load SQL dump (if any, see `db apply`)
  * Run pending migrations

#### Version

Prints current database version.

```shell
% tree db/migrations
db/migrations
├── 20150613165259_create_books.rb
└── 20150613165900_create_authors.rb

% bundle exec lotus db migrate # Migrates to max migration (20150613165900)
% bundle exec lotus db version
20150613165900
```

---

Ref https://github.com/lotus/model/pull/196

Closes #136 
Closes #137 
Closes #138 