### PR TITLE
Removed slice web env database url

### DIFF
--- a/lib/lotus/generators/slice.rb
+++ b/lib/lotus/generators/slice.rb
@@ -70,11 +70,6 @@ module Lotus
         # Per environment .env
         #
         ['development', 'test'].each do |environment|
-          # Add WEB_DATABASE_URL="file:///db/web_development"
-          cli.append_to_file target.join(".env.#{ environment }") do
-            %(#{ opts[:upcase_slice_name] }_DATABASE_URL="file:///db/#{ opts[:slice_name] }_#{ environment }"\n)
-          end
-
           # Add WEB_SESSIONS_SECRET="abc123" (random hex)
           cli.append_to_file target.join(".env.#{ environment }") do
             %(#{ opts[:upcase_slice_name] }_SESSIONS_SECRET="#{ SecureRandom.hex(32) }"\n)

--- a/test/commands/new_test.rb
+++ b/test/commands/new_test.rb
@@ -662,7 +662,7 @@ describe Lotus::Commands::New do
     describe '.env.development' do
       it 'patches the file to reference slice env vars' do
         content = @root.join('.env.development').read
-        content.must_match %(WEB_DATABASE_URL="file:///db/web_development")
+        content.wont_match %(WEB_DATABASE_URL="file:///db/web_development")
         content.must_match %r{WEB_SESSIONS_SECRET="[\w]{64}"}
       end
     end
@@ -670,7 +670,7 @@ describe Lotus::Commands::New do
     describe '.env.test' do
       it 'patches the file to reference slice env vars' do
         content = @root.join('.env.test').read
-        content.must_match %(WEB_DATABASE_URL="file:///db/web_test")
+        content.wont_match %(WEB_DATABASE_URL="file:///db/web_test")
         content.must_match %r{WEB_SESSIONS_SECRET="[\w]{64}"}
       end
     end

--- a/test/integration/cli/generate_test.rb
+++ b/test/integration/cli/generate_test.rb
@@ -158,10 +158,10 @@ template=#{ template_engine }
         content.must_match %(mount Api::Application, at: '/api')
         content.must_match %(require_relative '../apps/api/application')
         content = @root.join('.env.development').read
-        content.must_match %(API_DATABASE_URL)
+        content.wont_match %(API_DATABASE_URL)
         content.must_match %(API_SESSIONS_SECRET)
         content = @root.join('.env.test').read
-        content.must_match %(API_DATABASE_URL)
+        content.wont_match %(API_DATABASE_URL)
         content.must_match %(API_SESSIONS_SECRET)
       end
 


### PR DESCRIPTION
This PR removes slice database url in .env files.

when you create a new application WEB_DATABASE_URL is no longer generated.