### PR TITLE
Added sqlite extension to database sqlite/sqlite3 url

### DIFF
--- a/lib/lotus/generators/application/container.rb
+++ b/lib/lotus/generators/application/container.rb
@@ -125,8 +125,8 @@ module Lotus
 
         def database_uri
           {
-            development: "#{database_base_uri}_development",
-            test: "#{database_base_uri}_test"
+            development: database_environment_uri(:development),
+            test: database_environment_uri(:test)
           }
         end
 
@@ -144,6 +144,15 @@ module Lotus
             "memory://localhost/#{app_name}"
           else
             "file:///db/#{app_name}"
+          end
+        end
+
+        def database_environment_uri(environment)
+          case @database
+          when 'sqlite', 'sqlite3'
+            "#{database_base_uri}_#{environment}.sqlite"
+          else
+            "#{database_base_uri}_#{environment}"
           end
         end
       end

--- a/test/commands/new_test.rb
+++ b/test/commands/new_test.rb
@@ -284,7 +284,7 @@ describe Lotus::Commands::New do
 
           it 'generates db config for sqlite' do
             content = @root.join('.env.development').read
-            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_development")
+            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_development.sqlite")
           end
 
           describe 'with non-simple application name' do
@@ -292,7 +292,7 @@ describe Lotus::Commands::New do
 
             it 'escapes the database url' do
               content = @root.join('.env.development').read
-              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_development")
+              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_development.sqlite")
             end
           end
         end
@@ -301,7 +301,7 @@ describe Lotus::Commands::New do
           let(:opts) { container_options.merge(database: 'sqlite3') }
           it 'generates db config for sqlite3' do
             content = @root.join('.env.development').read
-            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_development")
+            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_development.sqlite")
           end
 
           describe 'with non-simple application name' do
@@ -309,7 +309,7 @@ describe Lotus::Commands::New do
 
             it 'escapes the database url' do
               content = @root.join('.env.development').read
-              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_development")
+              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_development.sqlite")
             end
           end
         end
@@ -381,7 +381,7 @@ describe Lotus::Commands::New do
 
           it 'generates db config for sqlite' do
             content = @root.join('.env.test').read
-            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_test")
+            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_test.sqlite")
           end
 
           describe 'with non-simple application name' do
@@ -389,7 +389,7 @@ describe Lotus::Commands::New do
 
             it 'escapes the database url' do
               content = @root.join('.env.test').read
-              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_test")
+              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_test.sqlite")
             end
           end
         end
@@ -398,14 +398,14 @@ describe Lotus::Commands::New do
           let(:opts) { container_options.merge(database: 'sqlite3') }
           it 'generates db config for sqlite3' do
             content = @root.join('.env.test').read
-            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_test")
+            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_test.sqlite")
           end
 
           describe 'with non-simple application name' do
             let(:app_name) { "chirp'two" }
             it 'escapes the database url' do
               content = @root.join('.env.test').read
-              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_test")
+              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_test.sqlite")
             end
           end
         end


### PR DESCRIPTION
Added extension .sqlite in YOUR_APP_DATABASE_URL env if you choose `--database=sqlite` or `--database=sqlite3`

```ruby
CHIRP_DATABASE_URL="sqlite://db/chirp_test.sqlite"
```