### PR TITLE
Fix cannot generate migration error

### DIFF
--- a/lib/lotus/commands/generate.rb
+++ b/lib/lotus/commands/generate.rb
@@ -74,7 +74,7 @@ module Lotus
       # @since 0.3.0
       # @api private
       def generator
-        require "lotus/generators/#{ @type }"
+        require "lotus/generators/#{ @type }.rb"
         class_name = Utils::String.new(@type).classify
         Utils::Class.load!(GENERATORS_NAMESPACE % class_name).new(self)
       end


### PR DESCRIPTION
As you recently introduced the new migration feature, I tried to generate a migration in my test project but unfortunately it got an error:

![lotus_error](https://cloud.githubusercontent.com/assets/9031129/8261059/cdf43442-16f1-11e5-8d08-1fa8856e32dd.png)

After a while trying to figure out the cause, I came to a solution as you can see in this PR. I'm not sure whether this is the root cause (cause I know `require`'s parameter doesn't need a file extension), but it works for me anyway. Hope this helps :)

![lotus_success](https://cloud.githubusercontent.com/assets/9031129/8261066/d8db94ae-16f1-11e5-8b09-ec6dcd512857.png)


 