### PR TITLE
[#267] fix secret when generate new app with app architecture option

### DIFF
--- a/lib/lotus/generators/application/app/.env.development.tt
+++ b/lib/lotus/generators/application/app/.env.development.tt
@@ -1,3 +1,3 @@
 # Define ENV variables for development environment
 <%= config[:upcase_app_name] %>_DATABASE_URL="<%= config[:database_config][:uri][:development] %>"
-<%= config[:upcase_app_name] %>_SESSIONS_SECRET="<% SecureRandom.hex(32) %>"
+<%= config[:upcase_app_name] %>_SESSIONS_SECRET="<%= SecureRandom.hex(32) %>"

--- a/lib/lotus/generators/application/app/.env.test.tt
+++ b/lib/lotus/generators/application/app/.env.test.tt
@@ -1,3 +1,3 @@
 # Define ENV variables for test environment
 <%= config[:app_name].to_env_s %>_DATABASE_URL="<%= config[:database_config][:uri][:test] %>"
-<%= config[:upcase_app_name] %>_SESSIONS_SECRET="<% SecureRandom.hex(32) %>"
+<%= config[:upcase_app_name] %>_SESSIONS_SECRET="<%= SecureRandom.hex(32) %>"

--- a/test/commands/new_test.rb
+++ b/test/commands/new_test.rb
@@ -1041,6 +1041,7 @@ describe Lotus::Commands::New do
         content = @root.join('.env.development').read
         content.must_match %(# Define ENV variables for development environment)
         content.must_match %(CHIRP_DATABASE_URL="file:///db/chirp_development")
+        content.wont_match %(CHIRP_SESSIONS_SECRET="")
         content.must_match %(CHIRP_SESSIONS_SECRET=)
       end
 
@@ -1141,6 +1142,7 @@ describe Lotus::Commands::New do
         content = @root.join('.env.test').read
         content.must_match %(# Define ENV variables for test environment)
         content.must_match %(CHIRP_DATABASE_URL="file:///db/chirp_test")
+        content.wont_match %(CHIRP_SESSIONS_SECRET="")
         content.must_match %(CHIRP_SESSIONS_SECRET=)
       end
 


### PR DESCRIPTION
Resolves #267

We forgot `=` sign to print `SecureRandom.hex(32)` when you generate a new application with app architecture.