### PR TITLE
Fixing lotus routes when architecture is application

### DIFF
--- a/lib/lotus/commands/routes.rb
+++ b/lib/lotus/commands/routes.rb
@@ -2,11 +2,22 @@ module Lotus
   module Commands
     class Routes
       def initialize(environment)
-        environment.require_application_environment
+        @environment = environment
+        @environment.require_application_environment
       end
 
       def start
-        puts Lotus::Container.new.routes.inspector.to_s
+        app.routes.inspector.to_s
+      end
+
+      private
+
+      def app
+        if @environment.container?
+          Lotus::Container.new
+        else
+          Lotus::Application.applications.first.new
+        end
       end
     end
   end

--- a/test/commands/routes_test.rb
+++ b/test/commands/routes_test.rb
@@ -3,27 +3,72 @@ require 'lotus/commands/routes'
 require 'lotus/container'
 
 describe Lotus::Commands::Routes do
-  let(:routes) { Lotus::Commands::Routes.new }
+  let(:opts)   { Hash.new }
+  let(:env)    { Lotus::Environment.new(opts) }
+  let(:routes) { Lotus::Commands::Routes.new(env) }
 
-  before do
-    Lotus::Container.configure do
-      mount Backend::App, at: '/backend'
-      mount RackApp,      at: '/rackapp'
-      mount TinyApp,      at: '/'
+  describe 'container architecture' do
+    def architecture_options
+      Hash[architecture: architecture, environment: 'test/fixtures/microservices/config/environment']
+    end
+
+    let(:opts)         { architecture_options }
+    let(:architecture) { 'container' }
+
+    before do
+      Lotus::Container.configure do
+        mount Backend::App, at: '/backend'
+        mount RackApp,      at: '/rackapp'
+        mount TinyApp,      at: '/'
+      end
+    end
+
+    describe '#start' do
+      it 'print routes' do
+        expectations = [
+          %(/backend                       Backend::App),
+          %(/rackapp                       RackApp),
+          %(GET, HEAD  /                              TinyApp::Controllers::Home::Index)
+        ]
+
+        expectations.each do |expectation|
+          routes.start.must_include(expectation)
+        end
+      end
     end
   end
 
-  describe '#start' do
-    it 'print routes' do
-      expectations = [
-        %(/backend                       Backend::App),
-        %(/rackapp                       RackApp),
-        %(GET, HEAD  /                              TinyApp::Controllers::Home::Index)
-      ]
+  describe 'application architecture' do
+    def architecture_options
+      Hash[architecture: architecture, environment: 'test/fixtures/microservices/config/environment']
+    end
 
-      actual = Lotus::Container.new.routes.inspector.to_s
-      expectations.each do |expectation|
-        actual.must_include(expectation)
+    let(:opts)         { architecture_options }
+    let(:architecture) { 'app' }
+
+    before do
+      Lotus::Application.applications.clear
+
+      class MySingleApplication < Lotus::Application
+        configure do
+          routes do
+            get '/',        to: 'home#index'
+            get '/welcome', to: 'home#welcome'
+          end
+        end
+      end
+    end
+
+    describe '#start' do
+      it 'print routes' do
+        expectations = [
+          %(/                              MySingleApplication::Controllers::Home::Index),
+          %(/welcome                       MySingleApplication::Controllers::Home::Welcome)
+        ]
+
+        expectations.each do |expectation|
+          routes.start.must_include(expectation)
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves [lotus/router #60](https://github.com/lotus/router/issues/60)

Command lotus routes don't expect application architecture.