### PR TITLE
adds 'app' to 'generate' description on cli

### DIFF
--- a/lib/lotus/cli.rb
+++ b/lib/lotus/cli.rb
@@ -79,7 +79,7 @@ module Lotus
       end
     end
 
-    desc 'generate', 'generates action, model or migration'
+    desc 'generate', 'generates app, action, model or migration'
     method_option :application_base_url, desc: 'application base url',                                      type: :string
     method_option :path,                 desc: 'applications path',                                         type: :string
     method_option :url,                  desc: 'relative URL for action',                                   type: :string


### PR DESCRIPTION
The current description for `generate` suggests that it's only meant to be used to generate actions, models or migrations. 

Adding 'app' to it may save a few people a trip to the guides. :)