### PR TITLE
Add dotenv files to .gitignore by default

### DIFF
--- a/lib/lotus/generators/application/app/gitignore.tt
+++ b/lib/lotus/generators/application/app/gitignore.tt
@@ -1,2 +1,5 @@
 /db/<%= config[:app_name] %>_development
 /db/<%= config[:app_name] %>_test
+.env
+.env.test
+.env.development


### PR DESCRIPTION
Should we put dotenv files into `.gitignore` by default, as `dotenv` gem is shipped with the framework? 

Sometimes we may absent-mindedly forget to ignore our env files. :smile: 