### PR TITLE
Fix load container in lotus console

### DIFF
--- a/lib/lotus/commands/console.rb
+++ b/lib/lotus/commands/console.rb
@@ -28,8 +28,8 @@ module Lotus
 
         # Add convenience methods to the main:Object binding
         TOPLEVEL_BINDING.eval('self').send(:include, Methods)
-        Lotus::Application.preload_applications!
 
+        load_application
         engine.start
       end
 
@@ -56,6 +56,14 @@ module Lotus
             raise ArgumentError.new("Unknown console engine: #{ engine }")
           }
         )
+      end
+
+      def load_application
+        if @environment.container?
+          Lotus::Container.new
+        else
+          Lotus::Application.preload_applications!
+        end
       end
     end
   end

--- a/test/commands/console_test.rb
+++ b/test/commands/console_test.rb
@@ -169,10 +169,12 @@ describe Lotus::Commands::Console do
       before do
         @old_pwd = Dir.pwd
         Dir.chdir 'test/fixtures/microservices'
+        Lotus::Container.class_variable_set(:@@configuration, Proc.new{})
       end
 
       after do
         Dir.chdir @old_pwd
+        Lotus::Container.remove_class_variable(:@@configuration)
       end
 
       it 'requires that file and starts a console session' do
@@ -202,6 +204,14 @@ describe Lotus::Commands::Console do
         Hash[environment: 'test/fixtures/microservices/config/environment']
       }
 
+      before do
+        Lotus::Container.class_variable_set(:@@configuration, Proc.new{})
+      end
+
+      after do
+        Lotus::Container.remove_class_variable(:@@configuration)
+      end
+
       it 'requires that file and starts a console session' do
         console.stub :engine, @engine do
           console.start
@@ -230,10 +240,12 @@ describe Lotus::Commands::Console do
 
       @engine = Minitest::Mock.new
       @engine.expect(:start, nil)
+      Lotus::Container.class_variable_set(:@@configuration, Proc.new{})
     end
 
     after do
       Lotus::Utils::IO.silence_warnings { TOPLEVEL_BINDING = @old_main }
+      Lotus::Container.remove_class_variable(:@@configuration)
     end
 
     it 'mixes convenience methods into the TOPLEVEL_BINDING' do


### PR DESCRIPTION
If we run `lotus console` with container arch there is a problem generating routes with routes helpers.

An example, we have this container:
```ruby
# environment.rb
Lotus::Container.configure do
  mount Admin::Application, at: '/admin'
  mount CallCenter::Application, at: '/callcenter'
end

# apps/admin/config/routes.rb
get 'home', to: 'home#index', as: :home
```
if we launch `lotus console`
```ruby
# BEFORE
Admin::Routes.path(:home) #=> '/home'

# AFTER THIS FIX
Admin::Routes.path(:home) #=> '/admin/home'
```
