### PR TITLE
Introduced an extra separator for controller action in action generator

### DIFF
--- a/lib/lotus/generators/action.rb
+++ b/lib/lotus/generators/action.rb
@@ -10,6 +10,10 @@ module Lotus
       # @api private
       ACTION_SEPARATOR = /\/|\#/
 
+      # @since x.x.x
+      # @api private
+      ROUTE_ENDPOINT_SEPARATOR = '#'.freeze
+
       # @since 0.3.0
       # @api private
       SUFFIX           = '.rb'.freeze
@@ -119,7 +123,7 @@ module Lotus
 
         # Insert at the top of the file
         cli.insert_into_file _routes_path, before: /\A(.*)/ do
-          "get '#{ _route_url }', to: '#{ @name }'\n"
+          "get '#{ _route_url }', to: '#{ _route_endpoint }'\n"
         end
       end
 
@@ -127,6 +131,12 @@ module Lotus
       # @api private
       def _route_url
         options.fetch(:url, "/#{ @controller }")
+      end
+
+      # @since x.x.x
+      # @api private
+      def _route_endpoint
+        "#{ @controller }#{ROUTE_ENDPOINT_SEPARATOR}#{ @action }"
       end
 
       # @since 0.3.0

--- a/test/commands/generate_test.rb
+++ b/test/commands/generate_test.rb
@@ -148,6 +148,64 @@ describe Lotus::Commands::Generate do
       end
     end
 
+    # See https://github.com/lotus/lotus/issues/282
+    describe 'with slash separator' do
+      let(:target_name) { 'authors/index' }
+
+      before do
+        capture_io { command.start }
+      end
+
+      describe 'apps/web/config/routes.rb' do
+        it 'generates it' do
+          content = @root.join('apps/web/config/routes.rb').read
+          content.must_match %(get '/authors', to: 'authors#index')
+        end
+      end
+
+      describe 'apps/web/controllers/authors/index.rb' do
+        it 'generates it' do
+          content = @root.join('apps/web/controllers/authors/index.rb').read
+          content.must_match %(module Web::Controllers::Authors)
+        end
+      end
+
+      describe 'spec/web/controllers/authors/index_spec.rb' do
+        it 'generates it' do
+          content = @root.join('spec/web/controllers/authors/index_spec.rb').read
+          content.must_match %(require 'spec_helper')
+          content.must_match %(require_relative '../../../../apps/web/controllers/authors/index')
+          content.must_match %(describe Web::Controllers::Authors::Index do)
+          content.must_match %(  let(:action) { Web::Controllers::Authors::Index.new })
+        end
+      end
+
+      describe 'apps/web/views/authors/index.rb' do
+        it 'generates it' do
+          content = @root.join('apps/web/views/authors/index.rb').read
+          content.must_match %(module Web::Views::Authors)
+        end
+      end
+
+      describe 'spec/web/views/authors/index_spec.rb' do
+        it 'generates it' do
+          content = @root.join('spec/web/views/authors/index_spec.rb').read
+          content.must_match %(require 'spec_helper')
+          content.must_match %(require_relative '../../../../apps/web/views/authors/index')
+          content.must_match %(describe Web::Views::Authors::Index do)
+          content.must_match %(  let(:template)  { Lotus::View::Template.new('apps/web/templates/authors/index.html.erb') })
+          content.must_match %(  let(:view)      { Web::Views::Authors::Index.new(template, exposures) })
+        end
+      end
+
+      describe 'apps/web/templates/authors/index.html.erb' do
+        it 'generates it' do
+          content = @root.join('apps/web/templates/authors/index.html.erb').read
+          content.must_be :empty?
+        end
+      end
+    end
+
     describe 'with --skip-view flag' do
       let(:opts) { default_options.merge(skip_view: true) }
 


### PR DESCRIPTION
Introduced an extra separator for action generator in order to let devs with a shell that has a glob activated to not run in problems with `#` char.

The following syntax will be alternative:

```shell
lotus generate action web books#show
```

or

```shell
lotus generate action web books/show
```

Closes #282 