### PR TITLE
Some RSpec idioms

### DIFF
--- a/lib/lotus/generators/action/action_spec.rspec.tt
+++ b/lib/lotus/generators/action/action_spec.rspec.tt
@@ -4,7 +4,7 @@ describe <%= config[:app] %>::Controllers::<%= config[:controller] %>::<%= confi
   let(:action) { described_class.new }
   let(:params) { Hash[] }
 
-  it "is successful" do
+  it 'is successful' do
     response = action.call(params)
     expect(response[0]).to eq 200
   end

--- a/lib/lotus/generators/action/action_spec.rspec.tt
+++ b/lib/lotus/generators/action/action_spec.rspec.tt
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative '<%= config[:relative_action_path] %>'
 
 describe <%= config[:app] %>::Controllers::<%= config[:controller] %>::<%= config[:action] %> do

--- a/lib/lotus/generators/action/action_spec.rspec.tt
+++ b/lib/lotus/generators/action/action_spec.rspec.tt
@@ -1,7 +1,7 @@
 require_relative '<%= config[:relative_action_path] %>'
 
 describe <%= config[:app] %>::Controllers::<%= config[:controller] %>::<%= config[:action] %> do
-  let(:action) { <%= config[:app] %>::Controllers::<%= config[:controller] %>::<%= config[:action] %>.new }
+  let(:action) { described_class.new }
   let(:params) { Hash[] }
 
   it "is successful" do

--- a/lib/lotus/generators/action/view_spec.rspec.tt
+++ b/lib/lotus/generators/action/view_spec.rspec.tt
@@ -3,7 +3,7 @@ require_relative '<%= config[:relative_view_path] %>'
 describe <%= config[:app] %>::Views::<%= config[:controller] %>::<%= config[:action] %> do
   let(:exposures) { Hash[foo: 'bar'] }
   let(:template)  { Lotus::View::Template.new('<%= config[:template_path] %>') }
-  let(:view)      { <%= config[:app] %>::Views::<%= config[:controller] %>::<%= config[:action] %>.new(template, exposures) }
+  let(:view)      { described_class.new(template, exposures) }
   let(:rendered)  { view.render }
 
   it "exposes #foo" do

--- a/lib/lotus/generators/action/view_spec.rspec.tt
+++ b/lib/lotus/generators/action/view_spec.rspec.tt
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative '<%= config[:relative_view_path] %>'
 
 describe <%= config[:app] %>::Views::<%= config[:controller] %>::<%= config[:action] %> do

--- a/lib/lotus/generators/action/view_spec.rspec.tt
+++ b/lib/lotus/generators/action/view_spec.rspec.tt
@@ -6,7 +6,7 @@ describe <%= config[:app] %>::Views::<%= config[:controller] %>::<%= config[:act
   let(:view)      { described_class.new(template, exposures) }
   let(:rendered)  { view.render }
 
-  it "exposes #foo" do
+  it 'exposes #foo' do
     expect(view.foo).to eq exposures.fetch(:foo)
   end
 end

--- a/lib/lotus/generators/model/entity_spec.rspec.tt
+++ b/lib/lotus/generators/model/entity_spec.rspec.tt
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe <%= config[:model_name] %> do
   # place your tests here
 end

--- a/lib/lotus/generators/model/repository_spec.rspec.tt
+++ b/lib/lotus/generators/model/repository_spec.rspec.tt
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe <%= config[:model_name] %>Repository do
   # place your tests here
 end

--- a/test/commands/generate_test.rb
+++ b/test/commands/generate_test.rb
@@ -87,7 +87,7 @@ describe Lotus::Commands::Generate do
             content.must_match %(describe Web::Controllers::Dashboard::Index do)
             content.must_match %(  let(:action) { described_class.new })
             content.must_match %(  let(:params) { Hash[] })
-            content.must_match %(  it "is successful" do)
+            content.must_match %(  it 'is successful' do)
             content.must_match %(    response = action.call(params))
             content.must_match %(    expect(response[0]).to eq 200)
           end
@@ -131,7 +131,7 @@ describe Lotus::Commands::Generate do
             content.must_match %(  let(:template)  { Lotus::View::Template.new('apps/web/templates/dashboard/index.html.erb') })
             content.must_match %(  let(:view)      { described_class.new(template, exposures) })
             content.must_match %(  let(:rendered)  { view.render })
-            content.must_match %(  it "exposes #foo" do)
+            content.must_match %(  it 'exposes #foo' do)
             content.must_match %(    expect(view.foo).to eq exposures.fetch(:foo))
             content.must_match %(  end)
           end

--- a/test/commands/generate_test.rb
+++ b/test/commands/generate_test.rb
@@ -83,7 +83,6 @@ describe Lotus::Commands::Generate do
 
           it 'generates it' do
             content = @root.join('spec/web/controllers/dashboard/index_spec.rb').read
-            content.must_match %(require 'spec_helper')
             content.must_match %(require_relative '../../../../apps/web/controllers/dashboard/index')
             content.must_match %(describe Web::Controllers::Dashboard::Index do)
             content.must_match %(  let(:action) { Web::Controllers::Dashboard::Index.new })
@@ -126,7 +125,6 @@ describe Lotus::Commands::Generate do
 
           it 'generates it' do
             content = @root.join('spec/web/views/dashboard/index_spec.rb').read
-            content.must_match %(require 'spec_helper')
             content.must_match %(require_relative '../../../../apps/web/views/dashboard/index')
             content.must_match %(describe Web::Views::Dashboard::Index do)
             content.must_match %(  let(:exposures) { Hash[foo: 'bar'] })
@@ -424,7 +422,6 @@ describe Lotus::Commands::Generate do
 
           it 'generates it' do
             content = @root.join('spec/generate/entities/post_spec.rb').read
-            content.must_match %(require 'spec_helper')
             content.must_match %(RSpec.describe Post do)
             content.must_match %(end)
           end
@@ -446,7 +443,6 @@ describe Lotus::Commands::Generate do
 
           it 'generates it' do
             content = @root.join('spec/generate/repositories/post_repository_spec.rb').read
-            content.must_match %(require 'spec_helper')
             content.must_match %(RSpec.describe PostRepository do)
             content.must_match %(end)
           end

--- a/test/commands/generate_test.rb
+++ b/test/commands/generate_test.rb
@@ -85,7 +85,7 @@ describe Lotus::Commands::Generate do
             content = @root.join('spec/web/controllers/dashboard/index_spec.rb').read
             content.must_match %(require_relative '../../../../apps/web/controllers/dashboard/index')
             content.must_match %(describe Web::Controllers::Dashboard::Index do)
-            content.must_match %(  let(:action) { Web::Controllers::Dashboard::Index.new })
+            content.must_match %(  let(:action) { described_class.new })
             content.must_match %(  let(:params) { Hash[] })
             content.must_match %(  it "is successful" do)
             content.must_match %(    response = action.call(params))
@@ -129,7 +129,7 @@ describe Lotus::Commands::Generate do
             content.must_match %(describe Web::Views::Dashboard::Index do)
             content.must_match %(  let(:exposures) { Hash[foo: 'bar'] })
             content.must_match %(  let(:template)  { Lotus::View::Template.new('apps/web/templates/dashboard/index.html.erb') })
-            content.must_match %(  let(:view)      { Web::Views::Dashboard::Index.new(template, exposures) })
+            content.must_match %(  let(:view)      { described_class.new(template, exposures) })
             content.must_match %(  let(:rendered)  { view.render })
             content.must_match %(  it "exposes #foo" do)
             content.must_match %(    expect(view.foo).to eq exposures.fetch(:foo))


### PR DESCRIPTION
I took the opportunity to improve some of the generated RSpec specs. In summary:

* Removed explicit `require_relative` to the SUT file
* Replaced explicit class constants for SUT with `described_class`
* Removed redundant `spec_helper` requires since `.rspec` requires this for us
* Uses single-quoted `it` block strings for consistency

Hopefully these changes are not too opinionated, and thanks - I'm loving lotus! :heart: 