### PR TITLE
Ensure model generator checks for the presence of model name

### DIFF
--- a/lib/lotus/generators/model.rb
+++ b/lib/lotus/generators/model.rb
@@ -11,6 +11,12 @@ module Lotus
         super
 
         @model_name = Utils::String.new(name).classify
+
+        if @model_name.empty?
+          puts 'Missing model name'
+          exit 1
+        end
+
         cli.class.source_root(source)
       end
 

--- a/test/commands/generate_test.rb
+++ b/test/commands/generate_test.rb
@@ -216,6 +216,15 @@ describe Lotus::Commands::Generate do
       capture_io { command.start }
     end
 
+    describe 'without model name' do
+      let(:app_name) { '' }
+
+      it 'raises error' do
+        exception = -> { capture_io { command.start } }.must_raise SystemExit
+        exception.message.must_equal 'Missing model name'
+      end
+    end
+
     describe 'lib/generate/entities/post.rb' do
       it 'generates it' do
         content = @root.join('lib/generate/entities/post.rb').read


### PR DESCRIPTION
*What*: Model generator takes empty model name param, which is well..wrong:

```
bundle exec lotus generate model 
create  lib/boogie/entities/.rb
create  lib/boogie/repositories/_repository.rb
create  spec/boogie/entities/_spec.rb
create  spec/boogie/repositories/_repository_spec.rb
```

This PR is to ensure we exit if model name is not given