### PR TITLE
Disable welcome page in the test environment

### DIFF
--- a/lib/lotus/middleware.rb
+++ b/lib/lotus/middleware.rb
@@ -94,7 +94,7 @@ module Lotus
     # @api private
     # @since 0.2.0
     def _load_default_welcome_page_for(application)
-      unless application.routes.defined?
+      unless Lotus.env?(:test) || application.routes.defined?
         require 'lotus/welcome'
         use Lotus::Welcome
       end

--- a/test/integration/welcome_page_test.rb
+++ b/test/integration/welcome_page_test.rb
@@ -6,12 +6,14 @@ describe 'Welcome page' do
   include Rack::Test::Methods
 
   before do
+    ENV['LOTUS_ENV'] = 'development'
     @current_dir = Dir.pwd
     Dir.chdir FIXTURES_ROOT.join('welcome_app')
     @app = WelcomeApp::Application.new
   end
 
   after do
+    ENV['LOTUS_ENV'] = 'test'
     Dir.chdir @current_dir
     @current_dir = nil
   end
@@ -24,7 +26,7 @@ describe 'Welcome page' do
     last_response
   end
 
-  it 'shows a welcome page when no routes were set' do
+  it 'is shown when no routes were set in development environment' do
     get '/'
 
     response.status.must_equal 200


### PR DESCRIPTION
The first high-level feature test should not fail because the text cannot be found on the welcome page, but because the route is undefined.

**EDIT**: According to the Getting Started guide, in test env, a Page Not found would be returned instead

