### PR TITLE
Improve JRuby 9k Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 sudo: false
 cache: bundler
 install: true
+env:
+  global:
+    - JRUBY_OPTS=--dev
 script:
   - 'if [[ "$TRAVIS_RUBY_VERSION" =~ "jruby" ]]; then rvm get head && rvm reload && rvm use --install $TRAVIS_RUBY_VERSION; fi'
   - 'bundle install'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ rvm:
   - 2.2.3
   - rbx-2
   - jruby-9000
+  - jruby-9.0.1.0
   - jruby-head
   - ruby-head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: ruby
 sudo: false
 cache: bundler
-script: 'bundle exec rake test:coverage'
+install: true
+script:
+  - 'if [[ "$TRAVIS_RUBY_VERSION" =~ "jruby" ]]; then rvm get head && rvm reload && rvm use --install $TRAVIS_RUBY_VERSION; fi'
+  - 'bundle install'
+  - 'bundle exec rake test:coverage'
 rvm:
   - 2.0.0
   - 2.1.0
@@ -17,6 +21,7 @@ rvm:
   - 2.2.2
   - 2.2.3
   - rbx-2
+  - jruby-9000
   - jruby-head
   - ruby-head
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ gemspec
 
 if !ENV['TRAVIS']
   gem 'byebug', require: false, platforms: :mri if RUBY_VERSION >= '2.1.0'
+  gem 'pry',    require: false, platforms: :jruby
   gem 'yard',   require: false
 end
 

--- a/lib/lotus/generators/database_config.rb
+++ b/lib/lotus/generators/database_config.rb
@@ -51,7 +51,7 @@ module Lotus
       end
 
       def platform_prefix
-        :jdbc if Lotus::Utils.jruby?
+        'jdbc:'.freeze if Lotus::Utils.jruby?
       end
 
       def uri
@@ -85,7 +85,7 @@ module Lotus
         when 'sqlite', 'sqlite3'
           "#{ platform_prefix }#{ base_uri }_#{ environment }.sqlite"
         else
-          "#{ platform_prefix }#{ base_uri }_#{ environment }"
+          "#{ platform_prefix if sql? }#{ base_uri }_#{ environment }"
         end
       end
     end

--- a/lib/lotus/generators/database_config.rb
+++ b/lib/lotus/generators/database_config.rb
@@ -21,7 +21,7 @@ module Lotus
         @engine = engine
         @name = name
 
-        SUPPORTED_ENGINES.key?(engine) or fail "\"#{ engine }\" is not a valid database type"
+        SUPPORTED_ENGINES.key?(engine.to_s) or fail "\"#{ engine }\" is not a valid database type"
       end
 
       def to_hash
@@ -68,7 +68,11 @@ module Lotus
       def base_uri
         case engine
         when 'mysql', 'mysql2'
-          "mysql2://localhost/#{ name }"
+          if Lotus::Utils.jruby?
+            "mysql://localhost/#{ name }"
+          else
+            "mysql2://localhost/#{ name }"
+          end
         when 'postgresql', 'postgres'
           "postgres://localhost/#{ name }"
         when 'sqlite', 'sqlite3'

--- a/lib/lotus/views/default.rb
+++ b/lib/lotus/views/default.rb
@@ -8,6 +8,7 @@ module Lotus
     # @api private
     class Default
       include Lotus::View
+
       configuration.reset!
 
       layout nil
@@ -20,7 +21,7 @@ module Lotus
 
       def self.render(root, template_name, context)
         format   = context[:format]
-        template = DefaultTemplateFinder.new(root, template_name, format).find
+        template = DefaultTemplateFinder.new(self, root, template_name, format).find
 
         if template
           new(template, context).render

--- a/lib/lotus/views/default_template_finder.rb
+++ b/lib/lotus/views/default_template_finder.rb
@@ -5,9 +5,10 @@ module Lotus
       #
       # @since 0.2.0
       # @api private
-      def initialize(root, template_name, format)
-         @root    = root
-         @options = { template: template_name, format: format }
+      def initialize(view, root, template_name, format)
+        @view    = view
+        @root    = root
+        @options = { template: template_name, format: format }
       end
 
       private

--- a/lotusrb.gemspec
+++ b/lotusrb.gemspec
@@ -30,7 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor',             '~> 0.19'
   spec.add_dependency 'bundler',          '~> 1.6'
 
-  spec.add_development_dependency 'rake',      '~> 10'
-  spec.add_development_dependency 'minitest',  '~> 5'
-  spec.add_development_dependency 'rack-test', '~> 0.6'
+  spec.add_development_dependency 'minispec-metadata', '~> 3.2.1'
+  spec.add_development_dependency 'minitest',          '~> 5'
+  spec.add_development_dependency 'rack-test',         '~> 0.6'
+  spec.add_development_dependency 'rake',              '~> 10'
 end

--- a/test/commands/new/container_test.rb
+++ b/test/commands/new/container_test.rb
@@ -58,6 +58,8 @@ describe Lotus::Commands::New::Container do
     end
 
     describe 'databases' do
+      let(:adapter_prefix) { 'jdbc:' if Lotus::Utils.jruby? }
+
       it 'generates specific files for memory' do
         with_temp_dir do |original_wd|
           command = Lotus::Commands::New::Container.new({database: 'memory'}, 'new_container')
@@ -80,7 +82,7 @@ describe Lotus::Commands::New::Container do
 
       it 'generates specific files for filesystem' do
         with_temp_dir do |original_wd|
-          command = Lotus::Commands::New::Container.new({database: 'filesystem'}, 'new_container')
+          command = Lotus::Commands::New::Container.new({ database: 'filesystem' }, 'new_container')
           capture_io { command.start }
 
           fixture_root = original_wd.join('test', 'fixtures', 'commands', 'application', 'new_container')
@@ -100,18 +102,18 @@ describe Lotus::Commands::New::Container do
 
       it 'generates specific files for sqlite3' do
         with_temp_dir do |original_wd|
-          command = Lotus::Commands::New::Container.new({database: 'sqlite3'}, 'new_container')
+          command = Lotus::Commands::New::Container.new({ database: 'sqlite3' }, 'new_container')
           capture_io { command.start }
 
           fixture_root = original_wd.join('test', 'fixtures', 'commands', 'application', 'new_container')
           Dir.chdir('new_container') do
             actual_content = File.read('.env.development')
-            actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="sqlite://db/new_container_development.sqlite"'
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }sqlite://db/new_container_development.sqlite\"")
 
             actual_content = File.read('.env.test')
-            actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="sqlite://db/new_container_test.sqlite"'
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }sqlite://db/new_container_test.sqlite\"")
 
-            assert_generated_file(fixture_root.join('Gemfile.sqlite3'), 'Gemfile')
+            assert_generated_file(fixture_root.join("Gemfile.#{ adapter_prefix }sqlite3"), 'Gemfile')
             assert_generated_file(fixture_root.join('lib', 'new_container.sqlite3.rb'), 'lib/new_container.rb')
             assert_file_exists('db/migrations/.gitkeep')
           end
@@ -120,18 +122,18 @@ describe Lotus::Commands::New::Container do
 
       it 'generates specific files for postgres' do
         with_temp_dir do |original_wd|
-          command = Lotus::Commands::New::Container.new({database: 'postgres'}, 'new_container')
+          command = Lotus::Commands::New::Container.new({ database: 'postgres' }, 'new_container')
           capture_io { command.start }
 
           fixture_root = original_wd.join('test', 'fixtures', 'commands', 'application', 'new_container')
           Dir.chdir('new_container') do
             actual_content = File.read('.env.development')
-            actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="postgres://localhost/new_container_development"'
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_development\"")
 
             actual_content = File.read('.env.test')
-            actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="postgres://localhost/new_container_test"'
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_test\"")
 
-            assert_generated_file(fixture_root.join('Gemfile.postgres'), 'Gemfile')
+            assert_generated_file(fixture_root.join("Gemfile.#{ adapter_prefix }postgres"), 'Gemfile')
             assert_generated_file(fixture_root.join('lib', 'new_container.postgres.rb'), 'lib/new_container.rb')
             assert_file_exists('db/migrations/.gitkeep')
           end
@@ -140,18 +142,19 @@ describe Lotus::Commands::New::Container do
 
       it 'generates specific files for mysql2' do
         with_temp_dir do |original_wd|
-          command = Lotus::Commands::New::Container.new({database: 'mysql2'}, 'new_container')
+          database = Lotus::Utils.jruby? ? :mysql : :mysql2
+          command = Lotus::Commands::New::Container.new({ database: 'mysql2' }, 'new_container')
           capture_io { command.start }
 
           fixture_root = original_wd.join('test', 'fixtures', 'commands', 'application', 'new_container')
           Dir.chdir('new_container') do
             actual_content = File.read('.env.development')
-            actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="mysql2://localhost/new_container_development"'
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }#{ database }://localhost/new_container_development\"")
 
             actual_content = File.read('.env.test')
-            actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="mysql2://localhost/new_container_test"'
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }#{ database }://localhost/new_container_test\"")
 
-            assert_generated_file(fixture_root.join('Gemfile.mysql2'), 'Gemfile')
+            assert_generated_file(fixture_root.join("Gemfile.#{ adapter_prefix }mysql2"), 'Gemfile')
             assert_generated_file(fixture_root.join('lib', 'new_container.mysql2.rb'), 'lib/new_container.rb')
             assert_file_exists('db/migrations/.gitkeep')
           end
@@ -160,18 +163,18 @@ describe Lotus::Commands::New::Container do
 
       it 'generates specific files for postgres' do
         with_temp_dir do |original_wd|
-          command = Lotus::Commands::New::Container.new({database: 'postgres'}, 'new_container')
+          command = Lotus::Commands::New::Container.new({ database: 'postgres' }, 'new_container')
           capture_io { command.start }
 
           fixture_root = original_wd.join('test', 'fixtures', 'commands', 'application', 'new_container')
           Dir.chdir('new_container') do
             actual_content = File.read('.env.development')
-            actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="postgres://localhost/new_container_development"'
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_development\"")
 
             actual_content = File.read('.env.test')
-            actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="postgres://localhost/new_container_test"'
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_test\"")
 
-            assert_generated_file(fixture_root.join('Gemfile.postgres'), 'Gemfile')
+            assert_generated_file(fixture_root.join("Gemfile.#{ adapter_prefix }postgres"), 'Gemfile')
             assert_generated_file(fixture_root.join('lib', 'new_container.postgres.rb'), 'lib/new_container.rb')
             assert_file_exists('db/migrations/.gitkeep')
           end

--- a/test/commands/server_test.rb
+++ b/test/commands/server_test.rb
@@ -264,7 +264,7 @@ describe Lotus::Commands::Server do
     end
   end
 
-  describe 'code reloading' do
+  describe 'code reloading', engine: :mri do
     describe 'when enabled' do
       let(:opts) { Hash[code_reloading: true] }
 

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -474,7 +474,7 @@ describe Lotus::Environment do
     end
   end
 
-  describe '#code_reloading?' do
+  describe '#code_reloading?', engine: :mri do
     describe 'when not specified' do
       describe 'in the default env' do
         before do

--- a/test/fixtures/collaboration/apps/web/application.rb
+++ b/test/fixtures/collaboration/apps/web/application.rb
@@ -54,7 +54,12 @@ module Collaboration
       end
 
       controller.prepare do
+        # Always run CSRF Protection when running full stack integration specs, even when LOTUS_ENV is set to
+        # test (it may happen depending on the order of specs and the way minitest works)
+        before :set_csrf_token, :verify_csrf_token
+
         include Module.new {
+
           private
           def generate_csrf_token
             't0k3n'

--- a/test/fixtures/collaboration/apps/web/application.rb
+++ b/test/fixtures/collaboration/apps/web/application.rb
@@ -3,26 +3,30 @@ require 'lotus/model'
 require 'lotus/helpers'
 require 'securerandom'
 
-ADAPTER_TYPE =  if RUBY_ENGINE == 'jruby'
-                  require 'jdbc/sqlite3'
-                  Jdbc::SQLite3.load_driver
-                  'jdbc:sqlite'
-                else
-                  require 'sqlite3'
-                  'sqlite'
-                end
+ADAPTER_TYPE = if Lotus::Utils.jruby?
+                 require 'jdbc/sqlite3'
+                 Jdbc::SQLite3.load_driver
+
+                 'jdbc:sqlite'
+               else
+                 require 'sqlite3'
+
+                 'sqlite'
+               end
 
 require 'lotus/model/adapters/sql_adapter'
+
 db = Pathname.new(File.dirname(__FILE__)).join('../tmp/test.sqlite3')
 db.dirname.mkpath      # create directory if not exist
 db.delete if db.exist? # delete file if exist
-SQLITE_CONNECTION_STRING = "#{ADAPTER_TYPE}://#{ db }"
+
+SQLITE_CONNECTION_STRING = "#{ ADAPTER_TYPE }://#{ db }"
 
 DB = Sequel.connect(SQLITE_CONNECTION_STRING)
 
 DB.create_table :books do
   primary_key :id
-  String  :name
+  String :name
 end
 
 module Collaboration
@@ -30,7 +34,7 @@ module Collaboration
     configure do
       layout :application
       load_paths << 'app'
-      routes  'config/routes'
+      routes 'config/routes'
 
       serve_assets true
       sessions :cookie, secret: SecureRandom.hex

--- a/test/fixtures/commands/application/new_container/Gemfile.jdbc:mysql2
+++ b/test/fixtures/commands/application/new_container/Gemfile.jdbc:mysql2
@@ -1,0 +1,19 @@
+source 'https://rubygems.org'
+
+gem 'bundler'
+gem 'rake'
+
+gem 'lotusrb',     '0.5.0'
+gem 'lotus-model', '~> 0.5'
+
+
+gem 'jdbc-mysql'
+
+group :test do
+  gem 'minitest'
+  gem 'capybara'
+end
+
+group :production do
+  # gem 'puma'
+end

--- a/test/fixtures/commands/application/new_container/Gemfile.jdbc:postgres
+++ b/test/fixtures/commands/application/new_container/Gemfile.jdbc:postgres
@@ -1,0 +1,19 @@
+source 'https://rubygems.org'
+
+gem 'bundler'
+gem 'rake'
+
+gem 'lotusrb',     '0.5.0'
+gem 'lotus-model', '~> 0.5'
+
+
+gem 'jdbc-postgres'
+
+group :test do
+  gem 'minitest'
+  gem 'capybara'
+end
+
+group :production do
+  # gem 'puma'
+end

--- a/test/fixtures/commands/application/new_container/Gemfile.jdbc:sqlite3
+++ b/test/fixtures/commands/application/new_container/Gemfile.jdbc:sqlite3
@@ -1,0 +1,19 @@
+source 'https://rubygems.org'
+
+gem 'bundler'
+gem 'rake'
+
+gem 'lotusrb',     '0.5.0'
+gem 'lotus-model', '~> 0.5'
+
+
+gem 'jdbc-sqlite3'
+
+group :test do
+  gem 'minitest'
+  gem 'capybara'
+end
+
+group :production do
+  # gem 'puma'
+end

--- a/test/generators/database_config_test.rb
+++ b/test/generators/database_config_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'shellwords'
 require 'lotus/generators/database_config'
 
 describe Lotus::Generators::DatabaseConfig do
@@ -57,18 +58,36 @@ describe Lotus::Generators::DatabaseConfig do
   end
 
   describe '#to_hash' do
-    let(:engine) { 'postgres' }
-    let(:adapter_prefix) { :jdbc if Lotus::Utils.jruby? }
+    let(:adapter_prefix) { :'jdbc:' if Lotus::Utils.jruby? }
 
-    it 'returns a hash containing gem, connection URIs and type' do
-      database_config.to_hash.must_equal(
-        gem: (Lotus::Utils.jruby? ? 'jdbc-postgres' : 'pg'),
-        type: :sql,
-        uri: {
-          development: "#{ adapter_prefix }postgres://localhost/basecamp_development",
-          test: "#{ adapter_prefix }postgres://localhost/basecamp_test"
-        }
-      )
+    describe 'SQL databases' do
+      let(:engine) { 'postgres' }
+
+      it 'returns a hash containing gem, right connection URIs and type' do
+        database_config.to_hash.must_equal(
+          gem: (Lotus::Utils.jruby? ? 'jdbc-postgres' : 'pg'),
+          type: :sql,
+          uri: {
+            development: "#{ adapter_prefix }postgres://localhost/basecamp_development",
+            test: "#{ adapter_prefix }postgres://localhost/basecamp_test"
+          }
+        )
+      end
+    end
+
+    describe 'non-SQL databases' do
+      let(:engine) { 'filesystem' }
+
+      it 'returns a hash containing gem, right connection URIs and type' do
+        database_config.to_hash.must_equal(
+          gem: nil,
+          type: :file_system,
+          uri: {
+            development: "file:///db/basecamp_development",
+            test: "file:///db/basecamp_test"
+          }
+        )
+      end
     end
   end
 end

--- a/test/integration/full_stack_test.rb
+++ b/test/integration/full_stack_test.rb
@@ -5,21 +5,16 @@ require 'fixtures/collaboration/apps/web/application'
 describe 'A full stack Lotus application' do
   include Rack::Test::Methods
 
+  attr_reader :app
+
   before do
-    ENV['LOTUS_ENV'] = 'development'
-    @current_dir = Dir.pwd
     Dir.chdir FIXTURES_ROOT.join('collaboration/apps/web')
+
     @app = Collaboration::Application.new
   end
 
   after do
-    ENV['LOTUS_ENV'] = 'test'
-    Dir.chdir @current_dir
-    @current_dir = nil
-  end
-
-  def app
-    @app
+    Dir.chdir($pwd)
   end
 
   def response

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,10 @@ ENV_LOCALHOST = !!ENV['TRAVIS'] ? '0.0.0.0' : 'localhost'
 require 'minitest/autorun'
 require 'support/assertions'
 
+# Skip MRI specifc specs
+require 'minispec-metadata'
+MinispecMetadata.add_tag_string('~engine:mri') if RUBY_ENGINE != 'ruby'
+
 $:.unshift 'lib'
 require 'lotus'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,9 @@
 require 'rubygems'
 require 'bundler/setup'
 
+# Autoloading 'tilt/erb' in a non thread-safe way
+require 'tilt/erb'
+
 if ENV['COVERAGE'] == 'true'
   require 'simplecov'
   require 'coveralls'


### PR DESCRIPTION
I was just trying Lotus with the new release of jRuby and make me sad it doesn't actually work at all. Reading this discussion https://discuss.lotusrb.org/t/supported-ruby-vms/28 I noticed that are some interest by the community to support all `2.2` compliance engines.

This PR is my effort to support the latest stable version of jRuby.

- [x] Add jRuby 9k stable as officially supported engine (`travis.yml`)
- [x] Disable engine specific features tests (like code reloading)
- [x] Make tests to pass using jRuby 9k
  - [x] Unit specs
    - [x] commands/new/container_test.rb
  - [x] Integration specs
    - [x] Add `lotus-model`/`jdbc` integration https://github.com/lotus/model/pull/220
    - [x] `cli/database_test`
    - [x] `full_stack`
      - [x] `lotus-view` https://github.com/jruby/jruby/issues/2988#issuecomment-126820250 https://github.com/lotus/view/pull/79

**Major Issues**

-  <del>`lotus-controller` https://github.com/lotus/controller/issues/104#issuecomment-106839758 </del>
- <del>`lotus-view` https://github.com/jruby/jruby/issues/2988#issuecomment-126820250 https://github.com/lotus/view/pull/79 </del>