### PR TITLE
Add default assets directory only if exists

### DIFF
--- a/lib/lotus/config/assets.rb
+++ b/lib/lotus/config/assets.rb
@@ -11,7 +11,9 @@ module Lotus
       # @api private
       def initialize(root)
         @root = root
-        @paths = Array(DEFAULT_DIRECTORY)
+        @paths = []
+
+        @paths << DEFAULT_DIRECTORY if Dir.exist?( root.join(DEFAULT_DIRECTORY) )
       end
 
       # @since 0.1.0


### PR DESCRIPTION
I am using Lotus for a JSON API endpoint, so I not expect to have a public folder in my application. Without this modification, I get the following error:

```
Boot Error

Something went wrong while loading /Users/javier/my-api/config.ru

Errno::ENOENT: No such file or directory @ realpath_rec - /Users/javier/my-api/public

/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/config/assets.rb:39:in `realpath'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/config/assets.rb:39:in `realpath'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/config/assets.rb:39:in `realpath'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotus-utils-0.5.1/lib/lotus/utils/load_paths.rb:65:in `block in each'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotus-utils-0.5.1/lib/lotus/utils/load_paths.rb:64:in `each'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotus-utils-0.5.1/lib/lotus/utils/load_paths.rb:64:in `each'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/config/assets.rb:21:in `entries'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/middleware.rb:119:in `_load_asset_middlewares'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/middleware.rb:84:in `load_default_stack'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/middleware.rb:35:in `load!'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/loader.rb:172:in `_load_rack_middleware!'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/loader.rb:160:in `load_rack!'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/loader.rb:32:in `block in load!'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/loader.rb:28:in `synchronize'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/loader.rb:28:in `load!'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/application.rb:147:in `load!'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/lotusrb-0.4.1/lib/lotus/application.rb:111:in `initialize'
/Users/javier/my-api/config.ru:3:in `new'
/Users/javier/my-api/config.ru:3:in `block in inner_app'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/rack-1.6.4/lib/rack/builder.rb:55:in `instance_eval'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/rack-1.6.4/lib/rack/builder.rb:55:in `initialize'
/Users/javier/my-api/config.ru:1:in `new'
/Users/javier/my-api/config.ru:1:in `inner_app'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/shotgun-0.9.1/lib/shotgun/loader.rb:113:in `eval'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/shotgun-0.9.1/lib/shotgun/loader.rb:113:in `inner_app'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/shotgun-0.9.1/lib/shotgun/loader.rb:103:in `assemble_app'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/shotgun-0.9.1/lib/shotgun/loader.rb:86:in `proceed_as_child'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/shotgun-0.9.1/lib/shotgun/loader.rb:31:in `call!'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/shotgun-0.9.1/lib/shotgun/loader.rb:18:in `call'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/rack-1.6.4/lib/rack/lint.rb:49:in `_call'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/rack-1.6.4/lib/rack/lint.rb:37:in `call'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/rack-1.6.4/lib/rack/showexceptions.rb:24:in `call'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/rack-1.6.4/lib/rack/commonlogger.rb:33:in `call'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/rack-1.6.4/lib/rack/content_length.rb:15:in `call'
/Users/javier/.rvm/gems/ruby-2.2.2@my-api/gems/rack-1.6.4/lib/rack/handler/webrick.rb:88:in `service'
/Users/javier/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
/Users/javier/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
/Users/javier/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
```