### PR TITLE
Refactor generators database config

### DIFF
--- a/lib/lotus/generators/application/container.rb
+++ b/lib/lotus/generators/application/container.rb
@@ -1,5 +1,6 @@
 require 'shellwords'
 require 'lotus/generators/abstract'
+require 'lotus/generators/database_config'
 require 'lotus/generators/slice'
 
 module Lotus
@@ -9,23 +10,23 @@ module Lotus
         def initialize(command)
           super
 
-          @slice_generator       = Slice.new(command)
-          @lotus_head            = options.fetch(:lotus_head)
-          @test                  = options[:test]
-          @database              = options[:database]
-          @lotus_model_version   = '~> 0.4'
+          @slice_generator      = Slice.new(command)
+          @database_config      = DatabaseConfig.new(options[:database], app_name)
+          @lotus_head           = options.fetch(:lotus_head)
+          @test                 = options[:test]
+          @lotus_model_version  = '~> 0.4'
 
           cli.class.source_root(source)
         end
 
         def start
           opts      = {
-            app_name:              app_name,
-            lotus_head:            @lotus_head,
-            test:                  @test,
-            database:              @database,
-            database_config:       database_config,
-            lotus_model_version:   @lotus_model_version,
+            app_name:             app_name,
+            lotus_head:           @lotus_head,
+            test:                 @test,
+            database:             @database_config.engine,
+            database_config:      @database_config.to_hash,
+            lotus_model_version:  @lotus_model_version,
           }
 
           templates = {
@@ -45,7 +46,7 @@ module Lotus
             "lib/#{ app_name }/repositories"
           ]
 
-          empty_directories << if sql_database?
+          empty_directories << if @database_config.sql?
             "db/migrations"
           else
             "db"
@@ -68,7 +69,7 @@ module Lotus
             )
           end
 
-          if sql_database?
+          if @database_config.sql?
             templates.merge!(
               'schema.sql.tt' => 'db/schema.sql'
             )
@@ -90,7 +91,7 @@ module Lotus
           end
 
           unless git_dir_present?
-            cli.template(source.join(database_type == :file_system ? 'gitignore.tt' : '.gitignore'), target.join('.gitignore'), opts)
+            cli.template(source.join(@database_config.type == :file_system ? 'gitignore.tt' : '.gitignore'), target.join('.gitignore'), opts)
             cli.run("git init #{Shellwords.escape(target)}", capture: true)
           end
 
@@ -101,75 +102,6 @@ module Lotus
 
         def git_dir_present?
           File.directory?(source.join('.git'))
-        end
-
-        def database_config
-          {
-            gem: database_gem,
-            uri: database_uri,
-            type: database_type
-          }
-        end
-
-        def database_gem
-          {
-            'mysql'      => 'mysql',
-            'mysql2'     => 'mysql2',
-            'postgresql' => 'pg',
-            'postgres'   => 'pg',
-            'sqlite'     => 'sqlite3',
-            'sqlite3'    => 'sqlite3'
-          }[@database]
-        end
-
-        def database_type
-          case @database
-          when 'mysql', 'mysql2', 'postgresql', 'postgres', 'sqlite', 'sqlite3'
-            :sql
-          when 'filesystem'
-            :file_system
-          when 'memory'
-            :memory
-          end
-        end
-
-        def sql_database?
-          database_type == :sql
-        end
-
-        def database_uri
-          {
-            development: database_environment_uri(:development),
-            test: database_environment_uri(:test)
-          }
-        end
-
-        def database_base_uri
-          case @database
-          when 'mysql'
-            "mysql://localhost/#{app_name}"
-          when 'mysql2'
-            "mysql2://localhost/#{app_name}"
-          when 'postgresql', 'postgres'
-            "postgres://localhost/#{app_name}"
-          when 'sqlite', 'sqlite3'
-            "sqlite://db/#{Shellwords.escape(app_name)}"
-          when 'memory'
-            "memory://localhost/#{app_name}"
-          when 'filesystem'
-            "file:///db/#{app_name}"
-          else
-            raise "\"#{@database}\" is not a valid database type"
-          end
-        end
-
-        def database_environment_uri(environment)
-          case @database
-          when 'sqlite', 'sqlite3'
-            "#{database_base_uri}_#{environment}.sqlite"
-          else
-            "#{database_base_uri}_#{environment}"
-          end
         end
       end
     end

--- a/lib/lotus/generators/database_config.rb
+++ b/lib/lotus/generators/database_config.rb
@@ -1,0 +1,88 @@
+module Lotus
+  module Generators
+    class DatabaseConfig
+      SUPPORTED_ENGINES = {
+        'mysql'      => { type: :sql,         mri: 'mysql',   jruby: 'jdbc-mysql'    },
+        'mysql2'     => { type: :sql,         mri: 'mysql2',  jruby: 'jdbc-mysql'    },
+        'postgresql' => { type: :sql,         mri: 'pg',      jruby: 'jdbc-postgres' },
+        'postgres'   => { type: :sql,         mri: 'pg',      jruby: 'jdbc-postgres' },
+        'sqlite'     => { type: :sql,         mri: 'sqlite3', jruby: 'jdbc-sqlite3'  },
+        'sqlite3'    => { type: :sql,         mri: 'sqlite3', jruby: 'jdbc-sqlite3'  },
+        'filesystem' => { type: :file_system, mri: nil,       jruby: nil             },
+        'memory'     => { type: :memory,      mri: nil,       jruby: nil             }
+      }.freeze
+
+      attr_reader :engine, :name
+
+      def initialize(engine, name)
+        @engine = engine
+        @name = name
+
+        SUPPORTED_ENGINES.key?(engine) or fail "\"#{ engine }\" is not a valid database type"
+      end
+
+      def to_hash
+        {
+          gem: gem,
+          uri: uri,
+          type: type
+        }
+      end
+
+      def type
+        SUPPORTED_ENGINES[engine][:type]
+      end
+
+      def sql?
+        type == :sql
+      end
+
+      private
+
+      def platform
+        Lotus::Utils.jruby? ? :jruby : :mri
+      end
+
+      def platform_prefix
+        :jdbc if Lotus::Utils.jruby?
+      end
+
+      def uri
+        {
+          development: environment_uri(:development),
+          test: environment_uri(:test)
+        }
+      end
+
+      def gem
+        SUPPORTED_ENGINES[engine][platform]
+      end
+
+      def base_uri
+        case engine
+        when 'mysql'
+          "mysql://localhost/#{ name }"
+        when 'mysql2'
+          "mysql2://localhost/#{ name }"
+        when 'postgresql', 'postgres'
+          "postgres://localhost/#{ name }"
+        when 'sqlite', 'sqlite3'
+          "sqlite://db/#{ Shellwords.escape(name) }"
+        when 'memory'
+          "memory://localhost/#{ name }"
+        when 'filesystem'
+          "file:///db/#{ Shellwords.escape(name) }"
+        end
+      end
+
+      def environment_uri(environment)
+        case engine
+        when 'sqlite', 'sqlite3'
+          "#{ platform_prefix }#{ base_uri }_#{ environment }.sqlite"
+        else
+          "#{ platform_prefix }#{ base_uri }_#{ environment }"
+        end
+      end
+    end
+  end
+end

--- a/test/commands/new_test.rb
+++ b/test/commands/new_test.rb
@@ -1226,7 +1226,7 @@ describe Lotus::Commands::New do
 
           it 'generates db config for sqlite' do
             content = @root.join('.env.development').read
-            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_development")
+            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_development.sqlite")
           end
 
           describe 'with non-simple application name' do
@@ -1234,7 +1234,7 @@ describe Lotus::Commands::New do
 
             it 'escapes the database url' do
               content = @root.join('.env.development').read
-              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_development")
+              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_development.sqlite")
             end
           end
         end
@@ -1243,7 +1243,7 @@ describe Lotus::Commands::New do
           let(:opts) { container_options.merge(database: 'sqlite3') }
           it 'generates db config for sqlite3' do
             content = @root.join('.env.development').read
-            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_development")
+            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_development.sqlite")
           end
 
           describe 'with non-simple application name' do
@@ -1251,7 +1251,7 @@ describe Lotus::Commands::New do
 
             it 'escapes the database url' do
               content = @root.join('.env.development').read
-              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_development")
+              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_development.sqlite")
             end
           end
         end
@@ -1329,7 +1329,7 @@ describe Lotus::Commands::New do
 
           it 'generates db config for sqlite' do
             content = @root.join('.env.test').read
-            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_test")
+            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_test.sqlite")
           end
 
           describe 'with non-simple application name' do
@@ -1337,23 +1337,24 @@ describe Lotus::Commands::New do
 
             it 'escapes the database url' do
               content = @root.join('.env.test').read
-              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_test")
+              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_test.sqlite")
             end
           end
         end
 
         describe 'with sqlite3' do
           let(:opts) { container_options.merge(database: 'sqlite3') }
+
           it 'generates db config for sqlite3' do
             content = @root.join('.env.test').read
-            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_test")
+            content.must_match %(CHIRP_DATABASE_URL="sqlite://db/chirp_test.sqlite")
           end
 
           describe 'with non-simple application name' do
             let(:app_name) { "chirp'two" }
             it 'escapes the database url' do
               content = @root.join('.env.test').read
-              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_test")
+              content.must_match %(CHIRP_TWO_DATABASE_URL="sqlite://db/chirp\\'two_test.sqlite")
             end
           end
         end

--- a/test/generators/database_config_test.rb
+++ b/test/generators/database_config_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+require 'lotus/generators/database_config'
+
+describe Lotus::Generators::DatabaseConfig do
+  let(:database_config) { Lotus::Generators::DatabaseConfig.new(engine, 'basecamp') }
+
+  describe '#type' do
+    describe 'when engine is SQL Database' do
+      let(:engine) { 'sqlite' }
+
+      it 'returns `:sql` symbol' do
+        database_config.type.must_equal :sql
+      end
+    end
+
+    describe 'when engine is filesystem' do
+      let(:engine) { 'filesystem' }
+
+      it 'returns `:file_system` symbol' do
+        database_config.type.must_equal :file_system
+      end
+    end
+
+    describe 'when engine is memory' do
+      let(:engine) { 'memory' }
+
+      it 'returns `:file_system` symbol' do
+        database_config.type.must_equal :memory
+      end
+    end
+  end
+
+  describe '#sql?' do
+    describe 'when engine is SQL Database' do
+      %w(sqlite sqlite3 postgresql postgres mysql mysql2).each do |e|
+        let(:engine) { e }
+
+        it 'returns true' do
+          database_config.sql?.must_equal true
+        end
+      end
+    end
+
+    describe 'when engine is non-SQL' do
+      %w(file_system memory).each do |e|
+        let(:engine) { e }
+
+        it 'returns false' do
+          database_config.sql?.must_equal false
+        end
+      end
+    end
+  end
+
+  describe '#to_hash' do
+    let(:engine) { 'postgres' }
+    let(:adapter_prefix) { :jdbc if Lotus::Utils.jruby? }
+
+    it 'returns a hash containing gem, connection URIs and type' do
+      database_config.to_hash.must_equal(
+        gem: (Lotus::Utils.jruby? ? 'jdbc-postgres' : 'pg'),
+        type: :sql,
+        uri: {
+          development: "#{ adapter_prefix }postgres://localhost/basecamp_development",
+          test: "#{ adapter_prefix }postgres://localhost/basecamp_test"
+        }
+      )
+    end
+  end
+end

--- a/test/integration/cli/database_test.rb
+++ b/test/integration/cli/database_test.rb
@@ -1,12 +1,13 @@
 require 'test_helper'
 require 'sequel'
+require 'fileutils'
 
 describe 'lotus db' do
-  ARCHITECTURES = ['container', 'app']
+  ARCHITECTURES = %w(container app)
 
   def create_temporary_dir
     @tmp = Pathname.new(@pwd = Dir.pwd).join('tmp/integration/cli/database')
-    @tmp.rmtree if @tmp.exist?
+    FileUtils.rm_rf(@tmp)
     @tmp.mkpath
 
     Dir.chdir(@tmp)

--- a/test/integration/cli/generate_test.rb
+++ b/test/integration/cli/generate_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'fileutils'
 
 describe 'lotus generate' do
   describe 'action' do
@@ -13,7 +14,7 @@ describe 'lotus generate' do
 
     def create_temporary_dir
       @tmp = Pathname.new(@pwd = Dir.pwd).join('tmp/integration/cli/generate')
-      @tmp.rmtree if @tmp.exist?
+      FileUtils.rm_rf(@tmp)
       @tmp.mkpath
 
       Dir.chdir(@tmp)


### PR DESCRIPTION
- Extract common behaviour between generators (app, container)
- Add unit specs covering generators'  database config logic
- Add multi-platform support (mri, jruby)
- Normalize behaviour of database configuration between App and Container generators (add `.sqlite` into database name when SQLite engine)

I'm aware of #324, but I'm taking a different approach, instead dumping all database config logic into `Abstract` class (where I believe we should only define interface, not logic) I extracted to a new class `DatabaseConfig`. It think this should be incorporated in #324 