### PR TITLE
Add logger option on Lotus configuration

### DIFF
--- a/lib/lotus/configuration.rb
+++ b/lib/lotus/configuration.rb
@@ -1642,11 +1642,38 @@ module Lotus
       @view ||= Config::FrameworkConfiguration.new
     end
 
-    # This options is used to set/get the application_module logger instance
+    # Defines a logger instance to the configuration
+    #
+    # This logger instance will be used to set the logger available on application module
+    #
+    # If no logger instance is defined, a Lotus::Logger will be set by default
     #
     # @return [Logger, NilClass] logger instance
     #
-    # @since 0.4.0
+    # @since x.x.x
+    #
+    # @example Define a logger
+    #   require 'lotus'
+    #
+    #   module Bookshelf
+    #     class Application < Lotus::Application
+    #       configure do
+    #         logger Logger.new(STDOUT)
+    #       end
+    #       load!
+    #     end
+    #
+    #     module Controllers::Error
+    #       include Bookshelf::Controller
+    #
+    #       action 'Index' do
+    #         def call(params)
+    #           Bookshelf::Logger.info "Logging to STDOUT"
+    #         end
+    #       end
+    #     end
+    #   end
+    #
     def logger(value = nil)
       if value.nil?
         @logger

--- a/lib/lotus/configuration.rb
+++ b/lib/lotus/configuration.rb
@@ -1642,6 +1642,19 @@ module Lotus
       @view ||= Config::FrameworkConfiguration.new
     end
 
+    # This options is used to set/get the application_module logger instance
+    #
+    # @return [Logger, NilClass] logger instance
+    #
+    # @since 0.4.0
+    def logger(value = nil)
+      if value.nil?
+        @logger
+      else
+        @logger = value
+      end
+    end
+
     # This options is used as a bridge between container and router application.
     #
     # @return [String, NilClass] path prefix for routes
@@ -1657,6 +1670,7 @@ module Lotus
     end
 
     private
+
     # @since 0.2.0
     # @api private
     def evaluate_configurations!

--- a/lib/lotus/loader.rb
+++ b/lib/lotus/loader.rb
@@ -112,8 +112,10 @@ module Lotus
 
     def _configure_logger!
       unless application_module.const_defined?('Logger', false)
-        logger = configuration.logger || Lotus::Logger.new(application_module.to_s)
-        application_module.const_set('Logger', logger)
+        if configuration.logger.nil?
+          configuration.logger Lotus::Logger.new(application_module.to_s)
+        end
+        application_module.const_set('Logger', configuration.logger)
       end
     end
 

--- a/lib/lotus/loader.rb
+++ b/lib/lotus/loader.rb
@@ -112,7 +112,7 @@ module Lotus
 
     def _configure_logger!
       unless application_module.const_defined?('Logger', false)
-        logger = Lotus::Logger.new(application_module.to_s)
+        logger = configuration.logger || Lotus::Logger.new(application_module.to_s)
         application_module.const_set('Logger', logger)
       end
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -825,4 +825,29 @@ describe Lotus::Configuration do
       end
     end
   end
+
+  describe '#logger' do
+    describe "when not previously set" do
+      before do
+        @configuration = Lotus::Configuration.new
+      end
+
+      it 'defaults to nil' do
+        @configuration.logger.must_be :nil?
+      end
+    end
+
+    describe "when the logger is set" do
+      before do
+        @logger = Logger.new(STDOUT)
+        @configuration = Lotus::Configuration.new
+        @configuration.logger @logger
+      end
+
+      it 'returns logger instance' do
+        @configuration.logger.must_equal @logger
+      end
+    end
+  end
+
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -833,7 +833,7 @@ describe Lotus::Configuration do
       end
 
       it 'defaults to nil' do
-        @configuration.logger.must_be :nil?
+        @configuration.logger.must_be_nil
       end
     end
 

--- a/test/loader_test.rb
+++ b/test/loader_test.rb
@@ -99,6 +99,19 @@ describe Lotus::Loader do
 
           output.must_match(/BeerShop/)
         end
+
+        it 'supports configured custom logger' do
+          class MyLogger < Logger; end
+          module DrinkShop
+            class Application < Lotus::Application
+              configure do
+                logger MyLogger.new(STDOUT)
+              end
+              load!
+            end
+          end
+          DrinkShop::Logger.must_be_instance_of MyLogger
+        end
       end
     end
 


### PR DESCRIPTION
I've added a logger method on Lotus Configuration to make life easier :)

This allow to define a different logger instance by environment, avoiding to redefine logger class by hand, like this:

```ruby
configure :development do
  logger Logger.new(STDOUT)
end
```

```ruby
configure :production do
  # production configs here
  logger Logger.new("/var/log/app.log")
end
```

To use on application:

```ruby
module Bookshelf::Controllers::Books
  class Index
    include Bookshelf::Action
    def call(params)
      Bookshelf::Logger.info "Lotus rules!"
    end
  end
end
```