### PR TITLE
Removed multiple CI version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,8 @@ cache: bundler
 script: 'bundle exec rake test:coverage'
 rvm:
   - 2.0.0
-  - 2.1.0
-  - 2.1.1
-  - 2.1.2
-  - 2.1.3
-  - 2.1.4
-  - 2.1.5
-  - 2.1.6
-  - 2.1.7
-  - 2.2.0
-  - 2.2.1
-  - 2.2.2
-  - 2.2.3
+  - 2.1
+  - 2.2
   - rbx-2
   - jruby-head
   - ruby-head


### PR DESCRIPTION
Hi, as of now we are running CI for 16 various Ruby versions. shall we remove each specific version and test with only the latest stable release?
```
rvm:
  2.0
  2.1
  2.2
  rbx-2
  jruby-head
  ruby-head
```
This will ensure only the latest patch as well we can help travis by reducing the CI count....

If there is a specific reason then kindly Ignore this PR...
This is one of my suggestion...