### PR TITLE
Default value 'self' for font-src CSP

### DIFF
--- a/lib/lotus/generators/application/app/config/application.rb.tt
+++ b/lib/lotus/generators/application/app/config/application.rb.tt
@@ -146,7 +146,7 @@ module <%= config[:classified_app_name] %>
       # Web applications can send this header to mitigate Cross Site Scripting
       # (XSS) attacks.
       #
-      # The default value allows images, scripts, AJAX, and CSS from the same
+      # The default value allows images, scripts, AJAX, fonts and CSS from the same
       # origin, and does not allow any other resources to load (eg object,
       # frame, media, etc).
       #
@@ -169,7 +169,7 @@ module <%= config[:classified_app_name] %>
       #  * http://content-security-policy.com/
       #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy
       #
-      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';"
+      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';"
 
       ##
       # FRAMEWORKS

--- a/lib/lotus/generators/slice/application.rb.tt
+++ b/lib/lotus/generators/slice/application.rb.tt
@@ -149,7 +149,7 @@ module <%= config[:classified_slice_name] %>
       # Web applications can send this header to mitigate Cross Site Scripting
       # (XSS) attacks.
       #
-      # The default value allows images, scripts, AJAX, and CSS from the same
+      # The default value allows images, scripts, AJAX, fonts and CSS from the same
       # origin, and does not allow any other resources to load (eg object,
       # frame, media, etc).
       #
@@ -172,7 +172,7 @@ module <%= config[:classified_slice_name] %>
       #  * http://content-security-policy.com/
       #  * https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy
       #
-      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';"
+      security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';"
 
       ##
       # FRAMEWORKS

--- a/test/commands/generate_test.rb
+++ b/test/commands/generate_test.rb
@@ -522,7 +522,7 @@ describe Lotus::Commands::Generate do
         content.must_match %('views')
         content.must_match %(routes 'config/routes')
         content.must_match %(security.x_frame_options "DENY")
-        content.must_match %(security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';")
+        content.must_match %(security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';")
         content.must_match %(controller.prepare do)
         content.must_match %(view.prepare do)
         content.must_match %(include Lotus::Helpers)

--- a/test/commands/new_test.rb
+++ b/test/commands/new_test.rb
@@ -815,7 +815,7 @@ describe Lotus::Commands::New do
 
         # security
         content.must_match %(security.x_frame_options "DENY")
-        content.must_match %(security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';")
+        content.must_match %(security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';")
 
         content.must_match %(controller.prepare)
         content.must_match %(view.prepare)
@@ -1683,7 +1683,7 @@ describe Lotus::Commands::New do
 
         # security
         content.must_match %(security.x_frame_options "DENY")
-        content.must_match %(security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';")
+        content.must_match %(security.content_security_policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';")
 
         content.must_match %(controller.prepare)
         content.must_match %(view.prepare)


### PR DESCRIPTION
Sets the content security policy font-src value to 'self' for all new and all generated apps using the provided templates.

Fixes #334 