### PR TITLE
Add destroy command line for action, model and migration

### DIFF
--- a/lib/lotus/cli.rb
+++ b/lib/lotus/cli.rb
@@ -98,6 +98,24 @@ module Lotus
       end
     end
 
+    desc 'destroy', 'destroys action, model or migration'
+    method_option :application_base_url, desc: 'application base url',                                      type: :string
+    method_option :path,                 desc: 'applications path',                                         type: :string
+    method_option :url,                  desc: 'relative URL for action',                                   type: :string
+    method_option :method,               desc: "HTTP method for action. Upper/lower case is ignored. Must be one of GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, TRACE.", type: :string, default: 'GET'
+    method_option :skip_view,            desc: 'skip the creation of view and templates (only for action)', type: :boolean, default: false
+    method_option :help, aliases: '-h',  desc: 'displays the usage method'
+
+    def destroy(type = nil, app_name = nil, name = nil)
+      if options[:help] || (type.nil? && app_name.nil? && name.nil?)
+        invoke :help, ['destroy']
+      else
+        require 'lotus/commands/generate'
+        self.behavior = :revoke
+        Lotus::Commands::Generate.new(type, app_name, name, environment, self).start
+      end
+    end
+
     require 'lotus/commands/db'
     register Lotus::Commands::DB, 'db', 'db [SUBCOMMAND]', 'manage set of DB operations'
 

--- a/lib/lotus/generators/action.rb
+++ b/lib/lotus/generators/action.rb
@@ -141,7 +141,7 @@ module Lotus
         FileUtils.touch(path)
 
         # Insert at the top of the file
-        cli.insert_into_file _routes_path, before: /\A(.*)/ do
+        cli.insert_into_file _routes_path, after: /\A/ do
           "#{ _http_method } '#{ _route_url }', to: '#{ _route_endpoint }'\n"
         end
       end

--- a/lib/lotus/generators/migration.rb
+++ b/lib/lotus/generators/migration.rb
@@ -25,11 +25,8 @@ module Lotus
       def initialize(command)
         super
 
-        timestamp = Time.now.utc.strftime(TIMESTAMP_FORMAT)
-        filename  = FILENAME % { timestamp: timestamp, name: name }
-
         env.require_application_environment
-        @destination = Lotus::Model.configuration.migrations.join(filename)
+        @destination = existing_migration || destination
 
         cli.class.source_root(source)
       end
@@ -52,6 +49,19 @@ module Lotus
       # @api private
       def name
         Utils::String.new(app_name || super).underscore
+      end
+
+      def destination
+        timestamp = Time.now.utc.strftime(TIMESTAMP_FORMAT)
+        filename  = FILENAME % { timestamp: timestamp, name: name }
+
+        Lotus::Model.configuration.migrations.join(filename)
+      end
+
+      def existing_migration
+        dirname = Lotus::Model.configuration.migrations
+
+        Dir.glob("#{dirname}/[0-9]*_#{name}.rb").first
       end
     end
   end

--- a/test/integration/cli/destroy_test.rb
+++ b/test/integration/cli/destroy_test.rb
@@ -1,0 +1,119 @@
+require 'test_helper'
+require 'fileutils'
+
+describe 'lotus destroy' do
+  let(:options)           { '' }
+  let(:app_name)          { 'web' }
+  let(:architecture)      { 'container' }
+  let(:template_engine)   { 'erb' }
+  let(:framework_testing) { 'minitest' }
+
+  def setup
+    create_temporary_dir
+    generate_application
+  end
+
+  def teardown
+    chdir_to_root
+  end
+
+  describe 'when application destroys an action' do
+    before do
+      generate_action 'dashboard#index'
+      generate_action 'playlist#index'
+      destroy_action 'dashboard#index'
+    end
+
+    it 'removes generated action files' do
+      @root.join('apps/web/controllers/dashboard/index.rb').wont_be      :exist?
+      @root.join('apps/web/views/dashboard/index.rb').wont_be            :exist?
+      @root.join('apps/web/templates/dashboard/index.html.erb').wont_be  :exist?
+      @root.join('spec/web/controllers/dashboard/index_spec.rb').wont_be :exist?
+      @root.join('spec/web/views/dashboard/index_spec.rb').wont_be       :exist?
+    end
+
+    it 'removes generated route' do
+      content = @root.join('apps/web/config/routes.rb').read
+
+      content.must_match %(get '/playlist', to: 'playlist#index')
+      content.wont_match %(get '/dashboard', to: 'dashboard#index')
+    end
+  end
+
+  describe 'when application destroys a model' do
+    before do
+      generate_model 'pizza'
+      destroy_model 'pizza'
+    end
+
+    it 'removes generated model files' do
+      @root.join('lib/delivery/entities/pizza.rb').wont_be                      :exist?
+      @root.join('lib/delivery/repositories/pizza_repository.rb').wont_be       :exist?
+      @root.join('spec/delivery/entities/pizza_spec.rb').wont_be                :exist?
+      @root.join('spec/delivery/repositories/pizza_repository_spec.rb').wont_be :exist?
+    end
+  end
+
+  describe 'when application destroys a migration' do
+    let(:options) { ' --database=sqlite3' }
+    let(:migrations_dir) { @root.join('db/migrations') }
+
+    before do
+      generate_migration 'create_books'
+      destroy_migration 'create_books'
+    end
+
+    it 'removes generated migration' do
+      Dir.glob("#{ migrations_dir }/[0-9]*_create_books.rb").must_be :empty?
+    end
+  end
+
+  def generate_action(action)
+    `bundle exec lotus generate action #{ app_name } #{ action }`
+  end
+
+  def destroy_action(action)
+    `bundle exec lotus destroy action #{ app_name } #{ action }`
+  end
+
+  def generate_model(model)
+    `bundle exec lotus generate model #{ model }`
+  end
+
+  def destroy_model(model)
+    `bundle exec lotus destroy model #{ model }`
+  end
+
+  def generate_migration(migration)
+    `bundle exec lotus generate migration #{ migration }`
+  end
+
+  def destroy_migration(migration)
+    `bundle exec lotus destroy migration #{ migration }`
+  end
+
+  def create_temporary_dir
+    @tmp = Pathname.new(@pwd = Dir.pwd).join('tmp/integration/cli/generate')
+    FileUtils.rm_rf(@tmp)
+    @tmp.mkpath
+
+    Dir.chdir(@tmp)
+  end
+
+  def generate_application
+    `bundle exec lotus new #{ @app_name = 'delivery' } --architecture=#{ architecture }#{ options }`
+    Dir.chdir(@root = @tmp.join(@app_name))
+
+    File.open(@root.join('.lotusrc'), 'w') do |f|
+      f.write <<-LOTUSRC
+architecture=#{ architecture }
+test=#{ framework_testing }
+template=#{ template_engine }
+      LOTUSRC
+    end
+  end
+
+  def chdir_to_root
+    Dir.chdir($pwd)
+  end
+end


### PR DESCRIPTION
Add destroy command to allow remove generated files and settings from
action, model and migrate generators.

Since Thor is used to generate the files, the destroy can be done by changing the behavior of the cli(Thor instance) before calling the respective generator.

Also need to make some changes to allow the destroy work properly:

* SHA: 9344fc7499abd3e9cf137862fb07b5fc0b9211c8 Prevent generate duplicates routes when the same command is called twice
* SHA: d8182e6f740ba2d5ad2f9de8c0867cd2f7f86ff2 Prevent generate duplicates migrations

closes #192