### PR TITLE
describe the expected behavior more explicitly

### DIFF
--- a/test/application_test.rb
+++ b/test/application_test.rb
@@ -13,7 +13,7 @@ describe Lotus::Application do
   end
 
   describe '.configure' do
-    it 'yields the given block and returns a configuration' do
+    it 'returns a valid configuration' do
       configuration = CoffeeShop::Application.configuration
 
       configuration.must_be_kind_of Lotus::Configuration


### PR DESCRIPTION
I'm looking into the tests (specs), I can see that some of them follow the rspec guideline of describing the method name (describe "#method) and notice that some tests aren't following this guideline correctly, do you want to have all the test following this "best practise"  ?

P.S : I put "best practise" into quotes, because I used to follow this practise for years with Rspec but I don't do it anymore. I'm currently following best practise advices from Nate Pryce and Steve Freeman about not duplicating code between spec and codebase, and describing only what is the method expected behavior to avoid changing the spec describe text when a method name is changed.
That being said and Lotus being a full framework, I can understand that you want to better layer of documentation on top of it, so I can dive into the spec to follow the Rspec guideline.