### PR TITLE
Adds Bundler as a runtime dependency

### DIFF
--- a/lotusrb.gemspec
+++ b/lotusrb.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'shotgun',          '~> 0.9'
   spec.add_dependency 'dotenv',           '~> 2.0'
   spec.add_dependency 'thor',             '~> 0.19'
+  spec.add_dependency 'bundler',          '~> 1.6'
 
-  spec.add_development_dependency 'bundler',   '~> 1.6'
   spec.add_development_dependency 'rake',      '~> 10'
   spec.add_development_dependency 'minitest',  '~> 5'
   spec.add_development_dependency 'rack-test', '~> 0.6'


### PR DESCRIPTION
I noticed that Lotus doesn't have `Bundler` as a runtime dependency, it doesn't seem like an issue but I saw a beginner Ruby developer struggling with that. He basically tried to follow Lotus tutorial and it didn't work because he didn't have bundler previously installed.

Adding `Bundler` as a runtime dependency since by default Lotus applications do use Bundler as a dependency manager.

```
➜  projects  lotus new bookshelf
      create  bookshelf/.lotusrc
      create  bookshelf/.env
      create  bookshelf/.env.development
      create  bookshelf/.env.test
      create  bookshelf/Gemfile
      create  bookshelf/config.ru
      create  bookshelf/config/environment.rb
      create  bookshelf/lib/bookshelf.rb
      create  bookshelf/lib/config/mapping.rb
      create  bookshelf/Rakefile
      create  bookshelf/spec/spec_helper.rb
      create  bookshelf/spec/features_helper.rb
      create  bookshelf/lib/bookshelf/entities/.gitkeep
      create  bookshelf/lib/bookshelf/repositories/.gitkeep
      create  bookshelf/lib/bookshelf/mailers/.gitkeep
      create  bookshelf/db/.gitkeep
      create  bookshelf/spec/bookshelf/entities/.gitkeep
      create  bookshelf/spec/bookshelf/repositories/.gitkeep
      create  bookshelf/spec/bookshelf/mailers/.gitkeep
      create  bookshelf/spec/support/.gitkeep
      create  bookshelf/.gitignore
         run  git init /Users/lucas/Projetos/open-source/bookshelf from "."
      insert  bookshelf/config/environment.rb
      insert  bookshelf/config/environment.rb
      append  bookshelf/.env.development
      append  bookshelf/.env.test
      create  bookshelf/apps/web/application.rb
      create  bookshelf/apps/web/config/routes.rb
      create  bookshelf/apps/web/views/application_layout.rb
      create  bookshelf/apps/web/templates/application.html.erb
      create  bookshelf/apps/web/controllers/.gitkeep
      create  bookshelf/apps/web/public/javascripts/.gitkeep
      create  bookshelf/apps/web/public/stylesheets/.gitkeep
      create  bookshelf/spec/web/features/.gitkeep
      create  bookshelf/spec/web/controllers/.gitkeep
      create  bookshelf/spec/web/views/.gitkeep
➜ projects  cd bookshelf 
total 24
-rw-r--r--  1 lucas  staff    57B  4 Oct 18:42 config.ru
drwxr-xr-x  2 lucas  staff   102B  4 Oct 18:42 config
-rw-r--r--  1 lucas  staff   164B  4 Oct 18:42 Rakefile
-rw-r--r--  1 lucas  staff   208B  4 Oct 18:42 Gemfile
drwxr-xr-x  5 lucas  staff   238B  4 Oct 18:42 spec
drwxr-xr-x  4 lucas  staff   170B  4 Oct 18:42 lib
drwxr-xr-x  2 lucas  staff   102B  4 Oct 18:42 db
drwxr-xr-x  3 lucas  staff   102B  4 Oct 18:42 apps
➜  bookshelf git:(master) ✗ ls
Gemfile   Rakefile  apps      config    config.ru db        lib       spec
➜  bookshelf git:(master) ✗ bundle install
zsh: command not found: bundle
```