### PR TITLE
Add destroy command

### DIFF
--- a/lib/lotus/cli.rb
+++ b/lib/lotus/cli.rb
@@ -109,5 +109,8 @@ module Lotus
 
     require 'lotus/cli_sub_commands/generate'
     register Lotus::CliSubCommands::Generate, 'generate', 'generate [SUBCOMMAND]', 'generate lotus classes'
+
+    require 'lotus/cli_sub_commands/destroy'
+    register Lotus::CliSubCommands::Destroy, 'destroy', 'destroy [SUBCOMMAND]', 'destroy lotus classes'
   end
 end

--- a/lib/lotus/cli_sub_commands/destroy.rb
+++ b/lib/lotus/cli_sub_commands/destroy.rb
@@ -1,0 +1,87 @@
+require 'lotus/routing/route'
+require 'lotus/commands/generate/action'
+
+module Lotus
+  class CliSubCommands
+    class Destroy < Thor
+      include Thor::Actions
+      namespace :destroy
+
+      desc 'action APPLICATION_NAME CONTROLLER_NAME#ACTION_NAME', 'destroy a lotus action'
+      long_desc <<-EOS
+        `lotus destroy action` will destroy an an action, view and template along with specs and a route.
+
+        For Application architecture the application name is 'app'. For Container architecture the default application is called 'web'.
+
+        > $ lotus destroy action app cars#index
+
+        > $ lotus destroy action other-app cars#index
+
+        > $ lotus destroy action web cars#create --method=post
+      EOS
+
+      method_option :method, desc: "The HTTP method used when the route was generated. Must be one of (#{Lotus::Routing::Route::VALID_HTTP_VERBS.join('/')})", default: Lotus::Commands::Generate::Action::DEFAULT_HTTP_METHOD
+      method_option :url, desc: 'Relative URL for action, will be used for the route', default: nil
+      method_option :template, desc: 'Extension used when the template was generated. Default is defined through your .lotusrc file.'
+
+      def actions(application_name, controller_and_action_name)
+        if options[:help]
+          invoke :help, ['action']
+        else
+          Lotus::Commands::Generate::Action.new(options, application_name, controller_and_action_name).destroy.start
+        end
+      end
+
+      desc 'migration NAME', 'destroy a migration'
+      long_desc <<-EOS
+      `lotus destroy migration` will destroy a migration file.
+
+      > $ lotus destroy migration create_books
+      EOS
+
+      def migration(name)
+        if options[:help]
+          invoke :help, ['migration']
+        else
+          require 'lotus/commands/generate/migration'
+          Lotus::Commands::Generate::Migration.new(options, name).destroy.start
+        end
+      end
+
+      desc 'model NAME', 'destroy an entity'
+      long_desc <<-EOS
+        `lotus destroy model` will destroy an entity along with repository
+        and corresponding tests
+
+        > $ lotus generate model car
+      EOS
+
+      def model(name)
+        if options[:help]
+          invoke :help, ['model']
+        else
+          require 'lotus/commands/generate/model'
+          Lotus::Commands::Generate::Model.new(options, name).destroy.start
+        end
+      end
+
+      desc 'mailer NAME', 'destroy a mailer'
+      long_desc <<-EOS
+      `lotus destroy mailer` will destroy a mailer, along with templates and specs.
+
+      > $ lotus destroy mailer forgot_password
+      EOS
+
+      def mailer(name)
+        if options[:help]
+          invoke :help, ['mailer']
+        else
+          require 'lotus/commands/generate/mailer'
+
+          options[:behavior] = :revoke
+          Lotus::Commands::Generate::Mailer.new(options, name).destroy.start
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/commands/generate/abstract.rb
+++ b/lib/lotus/commands/generate/abstract.rb
@@ -1,39 +1,39 @@
 require 'lotus/environment'
+require 'lotus/generators/generatable'
 require 'lotus/generators/test_framework'
 require 'lotus/version'
-require 'thor'
+require 'lotus/utils/string'
 
 module Lotus
   module Commands
     class Generate
       class Abstract
 
-        attr_reader :options, :base_path, :test_framework
+        include Lotus::Generators::Generatable
+
+        attr_reader :options, :target_path, :test_framework
 
         def initialize(options)
           @options = Lotus::Utils::Hash.new(options).symbolize!
           assert_options!
-          @base_path = Pathname.pwd
+
+          @target_path = Pathname.pwd
           @test_framework = Lotus::Generators::TestFramework.new(options[:test])
-        end
-
-        def start
-          raise NotImplementedError
-        end
-
-        private
-
-        def lotusrc_options
-          @lotusrc_options ||= Lotusrc.new(Pathname.new(base_path)).read
-        end
-
-        def environment
-          @environment ||= Lotus::Environment.new(options)
         end
 
         def template_source_path
           generator = self.class.name.split('::').last.downcase
           Pathname.new(::File.dirname(__FILE__) + "/../../generators/#{generator}/").realpath
+        end
+
+        private
+
+        def lotusrc_options
+          @lotusrc_options ||= Lotusrc.new(target_path).read
+        end
+
+        def environment
+          @environment ||= Lotus::Environment.new(options)
         end
 
         def template_engine

--- a/lib/lotus/commands/generate/app.rb
+++ b/lib/lotus/commands/generate/app.rb
@@ -1,6 +1,4 @@
 require 'lotus/commands/generate/abstract'
-require 'lotus/generators/generator'
-require 'lotus/utils/string'
 require 'lotus/application_name'
 require 'securerandom'
 
@@ -9,6 +7,8 @@ module Lotus
     class Generate
       class App < Abstract
 
+        attr_reader :base_path
+
         def initialize(options, application_name)
           super(options)
 
@@ -16,15 +16,36 @@ module Lotus
           assert_architecture!
 
           @application_name = ApplicationName.new(application_name)
-
-          @generator = Lotus::Generators::Generator.new(template_source_path, target_path)
+          @base_path = Pathname.pwd
         end
 
-        def start
+        def map_templates
+          add_mapping('application.rb.tt', 'application.rb')
+          add_mapping('config/routes.rb.tt', 'config/routes.rb')
+          add_mapping('views/application_layout.rb.tt', 'views/application_layout.rb')
+          add_mapping('templates/application.html.erb.tt', 'templates/application.html.erb')
+
+          add_mapping('.gitkeep', 'controllers/.gitkeep')
+          add_mapping('.gitkeep', 'public/javascripts/.gitkeep')
+          add_mapping('.gitkeep', 'public/stylesheets/.gitkeep')
+          add_mapping('.gitkeep', "../../spec/#{ app_name }/features/.gitkeep")
+          add_mapping('.gitkeep', "../../spec/#{ app_name }/controllers/.gitkeep")
+          add_mapping('.gitkeep', "../../spec/#{ app_name }/views/.gitkeep")
+        end
+
+        def template_options
+          {
+            app_name:            app_name,
+            upcase_app_name:     upcase_app_name,
+            classified_app_name: classified_app_name,
+            app_base_url:        application_base_url
+          }
+        end
+
+        def post_process_templates
           add_require_app
           add_mount_app
           add_web_session_secret
-          process_templates
         end
 
         private
@@ -35,13 +56,13 @@ module Lotus
 
         def add_require_app
           # Add "require_relative '../apps/web/application'"
-          @generator.inject_into_file base_path.join('config/environment.rb'), after: /require_relative '\.\.\/lib\/(.*)'/ do
+          generator.inject_into_file base_path.join('config/environment.rb'), after: /require_relative '\.\.\/lib\/(.*)'/ do
             "\nrequire_relative '../apps/#{ app_name }/application'"
           end
         end
 
         def add_mount_app
-          @generator.inject_into_file base_path.join('config/environment.rb'), after: /Lotus::Container.configure do/ do |match|
+          generator.inject_into_file base_path.join('config/environment.rb'), after: /Lotus::Container.configure do/ do |match|
             "\n  mount #{ classified_app_name }::Application, at: '#{ application_base_url }'"
           end
         end
@@ -49,7 +70,7 @@ module Lotus
         def add_web_session_secret
           ['development', 'test'].each do |environment|
             # Add WEB_SESSIONS_SECRET="abc123" (random hex)
-            @generator.append_to_file base_path.join(".env.#{ environment }") do
+            generator.append_to_file base_path.join(".env.#{ environment }") do
               %(#{ upcase_app_name }_SESSIONS_SECRET="#{ SecureRandom.hex(32) }"\n)
             end
           end
@@ -69,32 +90,6 @@ module Lotus
 
         def classified_app_name
           Utils::String.new(app_name).classify
-        end
-
-        def process_templates
-          @generator.add_mapping('application.rb.tt', 'application.rb')
-          @generator.add_mapping('config/routes.rb.tt', 'config/routes.rb')
-          @generator.add_mapping('views/application_layout.rb.tt', 'views/application_layout.rb')
-          @generator.add_mapping('templates/application.html.erb.tt', 'templates/application.html.erb')
-
-          @generator.add_mapping('.gitkeep', 'controllers/.gitkeep')
-          @generator.add_mapping('.gitkeep', 'public/javascripts/.gitkeep')
-          @generator.add_mapping('.gitkeep', 'public/stylesheets/.gitkeep')
-          @generator.add_mapping('.gitkeep', "../../spec/#{ app_name }/features/.gitkeep")
-          @generator.add_mapping('.gitkeep', "../../spec/#{ app_name }/controllers/.gitkeep")
-          @generator.add_mapping('.gitkeep', "../../spec/#{ app_name }/views/.gitkeep")
-
-
-          @generator.process_templates(template_options)
-        end
-
-        def template_options
-          {
-            app_name:            app_name,
-            upcase_app_name:     upcase_app_name,
-            classified_app_name: classified_app_name,
-            app_base_url:        application_base_url
-          }
         end
 
         def assert_application_name!(value)

--- a/lib/lotus/commands/generate/mailer.rb
+++ b/lib/lotus/commands/generate/mailer.rb
@@ -1,6 +1,4 @@
 require "lotus/commands/generate/abstract"
-require "lotus/generators/generator"
-require "lotus/utils/string"
 
 module Lotus
   module Commands
@@ -45,23 +43,18 @@ module Lotus
           @from             = options[:from] || DEFAULT_FROM
           @to               = options[:to] || DEFAULT_TO
           @subject          = options[:subject] || DEFAULT_SUBJECT
-          @generator        = Lotus::Generators::Generator.new(template_source_path, base_path)
 
           assert_name!
         end
 
-        # @since 0.5.0
+        # @since 0.x.x
         # @api private
-        def start
-          @generator.add_mapping("mailer_spec.rb.tt", mailer_spec_path)
-          @generator.add_mapping("mailer.rb.tt", mailer_path)
-          @generator.add_mapping("template.txt.tt", txt_template_path)
-          @generator.add_mapping("template.html.tt", html_template_path)
-
-          @generator.process_templates(template_options)
+        def map_templates
+          add_mapping("mailer_spec.rb.tt", mailer_spec_path)
+          add_mapping("mailer.rb.tt", mailer_path)
+          add_mapping("template.txt.tt", txt_template_path)
+          add_mapping("template.html.tt", html_template_path)
         end
-
-        private
 
         def template_options
           {
@@ -71,6 +64,8 @@ module Lotus
             subject: subject,
           }
         end
+
+        private
 
         # @since 0.5.0
         # @api private
@@ -117,7 +112,7 @@ module Lotus
         def core_root
           Pathname.new("lib").join(::File.basename(Dir.getwd))
         end
-     end
+      end
     end
   end
 end

--- a/lib/lotus/commands/generate/migration.rb
+++ b/lib/lotus/commands/generate/migration.rb
@@ -4,6 +4,9 @@ module Lotus
   module Commands
     class Generate
       class Migration < Abstract
+
+        attr_reader :name, :underscored_name
+
         # @since x.x.x
         # @api private
         #
@@ -18,30 +21,39 @@ module Lotus
         #   20150612160502_create_books.rb
         FILENAME_PATTERN = '%{timestamp}_%{name}.rb'.freeze
 
-        def initialize(options, migration_name)
+        def initialize(options, name)
           super(options)
-          @migration_name = migration_name
+
+          @name = name
+          @underscored_name = Utils::String.new(@name).underscore
 
           environment.require_application_environment
           assert_migration_name!
         end
 
         def map_templates
-          destination_path = Lotus::Model.configuration.migrations.join(filename)
           add_mapping('migration.rb.tt', destination_path)
         end
 
         private
 
-        def filename
-          timestamp = Time.now.utc.strftime(TIMESTAMP_FORMAT)
-          underscored_migration_name = Utils::String.new(@migration_name).underscore
+        def destination_path
+          existing_migration_path || new_migration_path
+        end
 
-          FILENAME_PATTERN % { timestamp: timestamp, name: underscored_migration_name}
+        def existing_migration_path
+          Dir.glob("#{Lotus::Model.configuration.migrations}/[0-9]*_#{underscored_name}.rb").first
+        end
+
+        def new_migration_path
+          timestamp = Time.now.utc.strftime(TIMESTAMP_FORMAT)
+          filename = FILENAME_PATTERN % { timestamp: timestamp, name: underscored_name}
+
+          Lotus::Model.configuration.migrations.join(filename)
         end
 
         def assert_migration_name!
-          if @migration_name.nil? || @migration_name.strip.empty?
+          if name.nil? || name.strip.empty?
             raise ArgumentError.new('Migration name nil or empty')
           end
         end

--- a/lib/lotus/commands/generate/migration.rb
+++ b/lib/lotus/commands/generate/migration.rb
@@ -1,6 +1,4 @@
 require 'lotus/commands/generate/abstract'
-require 'lotus/utils/string'
-require 'lotus/generators/generator'
 
 module Lotus
   module Commands
@@ -23,15 +21,14 @@ module Lotus
         def initialize(options, migration_name)
           super(options)
           @migration_name = migration_name
-          @generator = Lotus::Generators::Generator.new(template_source_path, base_path)
+
           environment.require_application_environment
           assert_migration_name!
         end
 
-        def start
+        def map_templates
           destination_path = Lotus::Model.configuration.migrations.join(filename)
-          @generator.add_mapping('migration.rb.tt', destination_path)
-          @generator.process_templates
+          add_mapping('migration.rb.tt', destination_path)
         end
 
         private

--- a/lib/lotus/commands/generate/model.rb
+++ b/lib/lotus/commands/generate/model.rb
@@ -1,6 +1,4 @@
 require 'lotus/commands/generate/abstract'
-require 'lotus/generators/generator'
-require 'lotus/utils/string'
 
 module Lotus
   module Commands
@@ -12,20 +10,22 @@ module Lotus
         def initialize(options, model_name)
           super(options)
           @model_name = Utils::String.new(model_name).classify
-          @generator = Lotus::Generators::Generator.new(template_source_path, base_path)
 
           assert_model_name!
         end
 
-        def start
-          @generator.add_mapping('entity.rb.tt', entity_path)
-          @generator.add_mapping('repository.rb.tt', repository_path)
-          @generator.add_mapping("entity_spec.#{ test_framework.framework }.tt", entity_spec_path,)
-          @generator.add_mapping("repository_spec.#{ test_framework.framework }.tt", repository_spec_path)
-
-          @generator.process_templates(model_name: model_name)
+        def map_templates
+          add_mapping('entity.rb.tt', entity_path)
+          add_mapping('repository.rb.tt', repository_path)
+          add_mapping("entity_spec.#{ test_framework.framework }.tt", entity_spec_path,)
+          add_mapping("repository_spec.#{ test_framework.framework }.tt", repository_spec_path)
         end
 
+        def template_options
+          {
+            model_name: model_name
+          }
+        end
 
         private
 
@@ -73,13 +73,13 @@ module Lotus
         # @since x.x.x
         # @api private
         def entity_spec_path
-          base_path.join('spec', ::File.basename(Dir.getwd), 'entities', "#{ model_name_underscored }_spec.rb")
+          target_path.join('spec', ::File.basename(Dir.getwd), 'entities', "#{ model_name_underscored }_spec.rb")
         end
 
         # @since x.x.x
         # @api private
         def repository_spec_path
-          base_path.join('spec', ::File.basename(Dir.getwd), 'repositories',
+          target_path.join('spec', ::File.basename(Dir.getwd), 'repositories',
             "#{ model_name_underscored }_repository_spec.rb")
         end
 

--- a/lib/lotus/commands/new/app.rb
+++ b/lib/lotus/commands/new/app.rb
@@ -1,87 +1,20 @@
-require 'shellwords'
-require 'lotus/generators/generator'
-require 'lotus/application_name'
-require 'lotus/commands/generate/app'
 require 'lotus/commands/new/abstract'
 
 module Lotus
   module Commands
-    class New < Thor
+    class New
       class App < Abstract
 
         def initialize(options, name)
           super(options, name)
-          assert_no_application_name!
-        end
-        private
-
-        def start_in_app_dir
-          process_templates
-          init_git
         end
 
-        def process_templates
+        def map_templates
           add_application_templates
           add_empty_directories
           add_test_templates
           add_sql_templates
           add_git_templates
-          @generator.process_templates(template_options)
-        end
-
-        def add_application_templates
-          @generator.add_mapping('lotusrc.tt', '.lotusrc')
-          @generator.add_mapping('.env.tt', '.env')
-          @generator.add_mapping('.env.development.tt', '.env.development')
-          @generator.add_mapping('.env.test.tt', '.env.test')
-          @generator.add_mapping('Gemfile.tt', 'Gemfile')
-          @generator.add_mapping('config.ru.tt', 'config.ru')
-          @generator.add_mapping('config/environment.rb.tt', 'config/environment.rb')
-          @generator.add_mapping('lib/app_name.rb.tt', "lib/#{ app_name }.rb")
-          @generator.add_mapping('lib/config/mapping.rb.tt', 'lib/config/mapping.rb')
-          @generator.add_mapping('config/application.rb.tt', 'config/application.rb')
-          @generator.add_mapping('config/routes.rb.tt', 'config/routes.rb')
-          @generator.add_mapping('views/application_layout.rb.tt', 'app/views/application_layout.rb')
-          @generator.add_mapping('templates/application.html.erb.tt', 'app/templates/application.html.erb')
-        end
-
-        def add_test_templates
-          if test_framework.rspec?
-            @generator.add_mapping('Rakefile.rspec.tt', 'Rakefile')
-            @generator.add_mapping('rspec.rspec.tt', '.rspec')
-            @generator.add_mapping('spec_helper.rb.rspec.tt', 'spec/spec_helper.rb')
-            @generator.add_mapping('features_helper.rb.rspec.tt', 'spec/features_helper.rb')
-            @generator.add_mapping('capybara.rb.rspec.tt', 'spec/support/capybara.rb')
-          else
-            @generator.add_mapping('Rakefile.minitest.tt', 'Rakefile')
-            @generator.add_mapping('spec_helper.rb.minitest.tt', 'spec/spec_helper.rb')
-            @generator.add_mapping('features_helper.rb.minitest.tt', 'spec/features_helper.rb')
-          end
-        end
-
-        def add_empty_directories
-          @generator.add_mapping('.gitkeep', 'app/controllers/.gitkeep')
-          @generator.add_mapping('.gitkeep', 'app/views/.gitkeep')
-          @generator.add_mapping('.gitkeep', "lib/#{ app_name }/entities/.gitkeep")
-          @generator.add_mapping('.gitkeep', "lib/#{ app_name }/repositories/.gitkeep")
-          @generator.add_mapping('.gitkeep', "lib/#{ app_name }/mailers/.gitkeep")
-          @generator.add_mapping('.gitkeep', "lib/#{ app_name }/mailers/templates/.gitkeep")
-          @generator.add_mapping('.gitkeep', 'public/javascripts/.gitkeep')
-          @generator.add_mapping('.gitkeep', 'public/stylesheets/.gitkeep')
-
-          @generator.add_mapping('.gitkeep', 'spec/features/.gitkeep')
-          @generator.add_mapping('.gitkeep', 'spec/controllers/.gitkeep')
-          @generator.add_mapping('.gitkeep', 'spec/views/.gitkeep')
-          @generator.add_mapping('.gitkeep', "spec/#{ app_name }/entities/.gitkeep")
-          @generator.add_mapping('.gitkeep', "spec/#{ app_name }/repositories/.gitkeep")
-          @generator.add_mapping('.gitkeep', "spec/#{ app_name }/mailers/.gitkeep")
-          @generator.add_mapping('.gitkeep', 'spec/support/.gitkeep')
-
-          if database_config.sql?
-            @generator.add_mapping('.gitkeep', 'db/migrations/.gitkeep')
-          else
-            @generator.add_mapping('.gitkeep', 'db/.gitkeep')
-          end
         end
 
         def template_options
@@ -98,6 +31,66 @@ module Lotus
           }
         end
 
+        def post_process_templates
+          init_git
+        end
+
+        private
+
+        def add_application_templates
+          add_mapping('lotusrc.tt', '.lotusrc')
+          add_mapping('.env.tt', '.env')
+          add_mapping('.env.development.tt', '.env.development')
+          add_mapping('.env.test.tt', '.env.test')
+          add_mapping('Gemfile.tt', 'Gemfile')
+          add_mapping('config.ru.tt', 'config.ru')
+          add_mapping('config/environment.rb.tt', 'config/environment.rb')
+          add_mapping('lib/app_name.rb.tt', "lib/#{ app_name }.rb")
+          add_mapping('lib/config/mapping.rb.tt', 'lib/config/mapping.rb')
+          add_mapping('config/application.rb.tt', 'config/application.rb')
+          add_mapping('config/routes.rb.tt', 'config/routes.rb')
+          add_mapping('views/application_layout.rb.tt', 'app/views/application_layout.rb')
+          add_mapping('templates/application.html.erb.tt', 'app/templates/application.html.erb')
+        end
+
+        def add_test_templates
+          if test_framework.rspec?
+            add_mapping('Rakefile.rspec.tt', 'Rakefile')
+            add_mapping('rspec.rspec.tt', '.rspec')
+            add_mapping('spec_helper.rb.rspec.tt', 'spec/spec_helper.rb')
+            add_mapping('features_helper.rb.rspec.tt', 'spec/features_helper.rb')
+            add_mapping('capybara.rb.rspec.tt', 'spec/support/capybara.rb')
+          else
+            add_mapping('Rakefile.minitest.tt', 'Rakefile')
+            add_mapping('spec_helper.rb.minitest.tt', 'spec/spec_helper.rb')
+            add_mapping('features_helper.rb.minitest.tt', 'spec/features_helper.rb')
+          end
+        end
+
+        def add_empty_directories
+          add_mapping('.gitkeep', 'app/controllers/.gitkeep')
+          add_mapping('.gitkeep', 'app/views/.gitkeep')
+          add_mapping('.gitkeep', "lib/#{ app_name }/entities/.gitkeep")
+          add_mapping('.gitkeep', "lib/#{ app_name }/repositories/.gitkeep")
+          add_mapping('.gitkeep', "lib/#{ app_name }/mailers/.gitkeep")
+          add_mapping('.gitkeep', "lib/#{ app_name }/mailers/templates/.gitkeep")
+          add_mapping('.gitkeep', 'public/javascripts/.gitkeep')
+          add_mapping('.gitkeep', 'public/stylesheets/.gitkeep')
+
+          add_mapping('.gitkeep', 'spec/features/.gitkeep')
+          add_mapping('.gitkeep', 'spec/controllers/.gitkeep')
+          add_mapping('.gitkeep', 'spec/views/.gitkeep')
+          add_mapping('.gitkeep', "spec/#{ app_name }/entities/.gitkeep")
+          add_mapping('.gitkeep', "spec/#{ app_name }/repositories/.gitkeep")
+          add_mapping('.gitkeep', "spec/#{ app_name }/mailers/.gitkeep")
+          add_mapping('.gitkeep', 'spec/support/.gitkeep')
+
+          if database_config.sql?
+            add_mapping('.gitkeep', 'db/migrations/.gitkeep')
+          else
+            add_mapping('.gitkeep', 'db/.gitkeep')
+          end
+        end
         def template_source_path
           Pathname.new(::File.dirname(__FILE__)).join('..', '..', 'generators', 'application', 'app').realpath
         end
@@ -109,13 +102,6 @@ module Lotus
         def classified_app_name
           Utils::String.new(app_name).classify
         end
-
-        def assert_no_application_name!
-          if options.key?(:application_name)
-            puts "'application_name' is only supported by container architecture but has been set with a value of '#{options[:application_name]}'. Option will be ignored."
-          end
-        end
-
       end
     end
   end

--- a/lib/lotus/commands/new/container.rb
+++ b/lib/lotus/commands/new/container.rb
@@ -1,84 +1,19 @@
-require 'shellwords'
-require 'lotus/generators/generator'
-require 'lotus/application_name'
 require 'lotus/commands/generate/app'
 require 'lotus/commands/new/abstract'
 
 module Lotus
   module Commands
-    class New < Thor
+    class New
       class Container < Abstract
+
         DEFAULT_APPLICATION_NAME = 'web'.freeze
 
-        private
-
-        def start_in_app_dir
-          process_templates
-          init_git
-          Lotus::Commands::Generate::App.new(app_generator_options, app_slice_name).start
-        end
-
-        # options that are forwarded to app generator
-        def app_generator_options
-          {
-            application_base_url: application_base_url
-          }
-        end
-
-        def app_slice_name
-          options.fetch(:application_name, DEFAULT_APPLICATION_NAME)
-        end
-
-        def process_templates
+        def map_templates
           add_application_templates
           add_empty_directories
           add_test_templates
           add_sql_templates
           add_git_templates
-          @generator.process_templates(template_options)
-        end
-
-        def add_application_templates
-          @generator.add_mapping('lotusrc.tt', '.lotusrc')
-          @generator.add_mapping('.env.tt', '.env')
-          @generator.add_mapping('.env.development.tt', '.env.development')
-          @generator.add_mapping('.env.test.tt', '.env.test')
-          @generator.add_mapping('Gemfile.tt', 'Gemfile')
-          @generator.add_mapping('config.ru.tt', 'config.ru')
-          @generator.add_mapping('config/environment.rb.tt', 'config/environment.rb')
-          @generator.add_mapping('lib/app_name.rb.tt', "lib/#{ app_name }.rb")
-          @generator.add_mapping('lib/config/mapping.rb.tt', 'lib/config/mapping.rb')
-        end
-
-        def add_test_templates
-          if test_framework.rspec?
-            @generator.add_mapping('Rakefile.rspec.tt', 'Rakefile')
-            @generator.add_mapping('rspec.rspec.tt', '.rspec')
-            @generator.add_mapping('spec_helper.rb.rspec.tt', 'spec/spec_helper.rb')
-            @generator.add_mapping('features_helper.rb.rspec.tt', 'spec/features_helper.rb')
-            @generator.add_mapping('capybara.rb.rspec.tt', 'spec/support/capybara.rb')
-          else # minitest (default)
-            @generator.add_mapping('Rakefile.minitest.tt', 'Rakefile')
-            @generator.add_mapping('spec_helper.rb.minitest.tt', 'spec/spec_helper.rb')
-            @generator.add_mapping('features_helper.rb.minitest.tt', 'spec/features_helper.rb')
-          end
-        end
-
-        def add_empty_directories
-          @generator.add_mapping('.gitkeep', "lib/#{ app_name }/entities/.gitkeep")
-          @generator.add_mapping('.gitkeep', "lib/#{ app_name }/repositories/.gitkeep")
-          @generator.add_mapping('.gitkeep', "lib/#{ app_name }/mailers/.gitkeep")
-          @generator.add_mapping('.gitkeep', "lib/#{ app_name }/mailers/templates/.gitkeep")
-          @generator.add_mapping('.gitkeep', "spec/#{ app_name }/entities/.gitkeep")
-          @generator.add_mapping('.gitkeep', "spec/#{ app_name }/repositories/.gitkeep")
-          @generator.add_mapping('.gitkeep', "spec/#{ app_name }/mailers/.gitkeep")
-          @generator.add_mapping('.gitkeep', 'spec/support/.gitkeep')
-
-          if database_config.sql?
-            @generator.add_mapping('.gitkeep', 'db/migrations/.gitkeep')
-          else
-            @generator.add_mapping('.gitkeep', 'db/.gitkeep')
-          end
         end
 
         def template_options
@@ -90,6 +25,70 @@ module Lotus
             database_config:       database_config.to_hash,
             lotus_model_version:   lotus_model_version,
           }
+        end
+
+        def post_process_templates
+          init_git
+          generate_app
+        end
+
+        private
+
+        def add_application_templates
+          add_mapping('lotusrc.tt', '.lotusrc')
+          add_mapping('.env.tt', '.env')
+          add_mapping('.env.development.tt', '.env.development')
+          add_mapping('.env.test.tt', '.env.test')
+          add_mapping('Gemfile.tt', 'Gemfile')
+          add_mapping('config.ru.tt', 'config.ru')
+          add_mapping('config/environment.rb.tt', 'config/environment.rb')
+          add_mapping('lib/app_name.rb.tt', "lib/#{ app_name }.rb")
+          add_mapping('lib/config/mapping.rb.tt', 'lib/config/mapping.rb')
+        end
+
+        def add_test_templates
+          if test_framework.rspec?
+            add_mapping('Rakefile.rspec.tt', 'Rakefile')
+            add_mapping('rspec.rspec.tt', '.rspec')
+            add_mapping('spec_helper.rb.rspec.tt', 'spec/spec_helper.rb')
+            add_mapping('features_helper.rb.rspec.tt', 'spec/features_helper.rb')
+            add_mapping('capybara.rb.rspec.tt', 'spec/support/capybara.rb')
+          else # minitest (default)
+            add_mapping('Rakefile.minitest.tt', 'Rakefile')
+            add_mapping('spec_helper.rb.minitest.tt', 'spec/spec_helper.rb')
+            add_mapping('features_helper.rb.minitest.tt', 'spec/features_helper.rb')
+          end
+        end
+
+        def add_empty_directories
+          add_mapping('.gitkeep', "lib/#{ app_name }/entities/.gitkeep")
+          add_mapping('.gitkeep', "lib/#{ app_name }/repositories/.gitkeep")
+          add_mapping('.gitkeep', "lib/#{ app_name }/mailers/.gitkeep")
+          add_mapping('.gitkeep', "lib/#{ app_name }/mailers/templates/.gitkeep")
+          add_mapping('.gitkeep', "spec/#{ app_name }/entities/.gitkeep")
+          add_mapping('.gitkeep', "spec/#{ app_name }/repositories/.gitkeep")
+          add_mapping('.gitkeep', "spec/#{ app_name }/mailers/.gitkeep")
+          add_mapping('.gitkeep', 'spec/support/.gitkeep')
+
+          if database_config.sql?
+            add_mapping('.gitkeep', 'db/migrations/.gitkeep')
+          else
+            add_mapping('.gitkeep', 'db/.gitkeep')
+          end
+        end
+
+        def generate_app
+          Lotus::Commands::Generate::App.new(app_options, app_slice_name).start
+        end
+
+        def app_options
+          {
+            application_base_url: application_base_url
+          }
+        end
+
+        def app_slice_name
+          options.fetch(:application_name, DEFAULT_APPLICATION_NAME)
         end
 
         def template_source_path

--- a/lib/lotus/generators/generatable.rb
+++ b/lib/lotus/generators/generatable.rb
@@ -9,6 +9,11 @@ module Lotus
         process_templates
       end
 
+      def destroy
+        generator.behavior = :revoke
+        self
+      end
+
       def generator
         @generator ||= Lotus::Generators::Generator.new(template_source_path, target_path)
       end

--- a/lib/lotus/generators/generatable.rb
+++ b/lib/lotus/generators/generatable.rb
@@ -1,0 +1,46 @@
+require 'lotus/generators/generator'
+
+module Lotus
+  module Generators
+    module Generatable
+
+      def start
+        map_templates
+        process_templates
+      end
+
+      def generator
+        @generator ||= Lotus::Generators::Generator.new(template_source_path, target_path)
+      end
+
+      def map_templates
+        raise NotImplementedError, "must implement the map_templates method"
+      end
+
+      def add_mapping(source, target)
+        generator.add_mapping(source, target)
+      end
+
+      def process_templates
+        generator.process_templates(template_options)
+        post_process_templates
+      end
+
+      def post_process_templates
+        nil
+      end
+
+      def template_options
+        {}
+      end
+
+      def template_source_path
+        raise NotImplementedError, "must implement the template_source_path method"
+      end
+
+      def target_path
+        raise NotImplementedError, "must implement the target_path method"
+      end
+    end
+  end
+end

--- a/lib/lotus/generators/generator.rb
+++ b/lib/lotus/generators/generator.rb
@@ -4,6 +4,10 @@ module Lotus
   module Generators
     class Generator
 
+      extend Forwardable
+
+      def_delegators :@processor, :run, :behavior=, :inject_into_file, :append_to_file, :prepend_to_file
+
       class Processor < Thor
         include Thor::Actions
       end
@@ -25,19 +29,6 @@ module Lotus
           @processor.template(@template_source_path.join(src), @target_path.join(dst), options)
         end
       end
-
-      def inject_into_file(file, config, &block)
-        @processor.inject_into_file(file, config, &block)
-      end
-
-      def append_to_file(file, &block)
-        @processor.append_to_file(file, &block)
-      end
-
-      def run(command, options)
-        @processor.run(command, options)
-      end
-
     end
   end
 end

--- a/test/commands/generate/action_test.rb
+++ b/test/commands/generate/action_test.rb
@@ -202,6 +202,110 @@ describe Lotus::Commands::Generate::Action do
     end
   end
 
+  describe '#destroy' do
+    describe 'with container architecture' do
+      it 'destroys action, specs and templates' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+
+          capture_io {
+            Lotus::Commands::Generate::Action.new({}, 'web', 'books#index').start
+
+            Lotus::Commands::Generate::Action.new({}, 'web', 'books#index').destroy.start
+          }
+
+          refute_file_exists('spec/web/controllers/books/index_spec.rb')
+          refute_file_exists('apps/web/controllers/books/index.rb')
+          refute_file_exists('apps/web/views/books/index.rb')
+          refute_file_exists('apps/web/templates/books/index.html.erb')
+          refute_file_exists('spec/web/views/books/index_spec.rb')
+        end
+      end
+    end
+
+    describe 'with app architecture' do
+      it 'destroys action, specs and templates' do
+        with_temp_dir do |original_wd|
+          setup_app_app
+
+          capture_io {
+            Lotus::Commands::Generate::Action.new({}, 'testapp', 'books#index').start
+
+            Lotus::Commands::Generate::Action.new({}, 'testapp', 'books#index').destroy.start
+          }
+
+          refute_file_exists('spec/controllers/books/index_spec.rb')
+          refute_file_exists('app/controllers/books/index.rb')
+          refute_file_exists('app/views/books/index.rb')
+          refute_file_exists('app/templates/books/index.html.erb')
+          refute_file_exists('spec/views/books/index_spec.rb')
+        end
+      end
+    end
+
+    it 'erases route configuration' do
+      with_temp_dir do |original_wd|
+        setup_container_app
+
+        capture_io {
+          Lotus::Commands::Generate::Action.new({}, 'web', 'books#index').start
+
+          Lotus::Commands::Generate::Action.new({}, 'web', 'books#index').destroy.start
+        }
+
+        refute_file_includes('apps/web/config/routes.rb', "get '/books', to: 'books#index'")
+      end
+    end
+
+    describe 'with --url' do
+      it 'erases route configuration' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+
+          capture_io {
+            Lotus::Commands::Generate::Action.new({url: '/mybooks'}, 'web', 'books#index').start
+
+            Lotus::Commands::Generate::Action.new({url: '/mybooks'}, 'web', 'books#index').destroy.start
+          }
+
+          refute_file_includes('apps/web/config/routes.rb', "get '/mybooks', to: 'books#index'")
+        end
+      end
+    end
+
+    describe 'with --method' do
+      it 'erases route configuration' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+
+          capture_io {
+            Lotus::Commands::Generate::Action.new({method: 'post'}, 'web', 'books#index').start
+
+            Lotus::Commands::Generate::Action.new({method: 'post'}, 'web', 'books#index').destroy.start
+          }
+
+          refute_file_includes('apps/web/config/routes.rb', "post '/books', to: 'books#index'")
+        end
+      end
+    end
+
+    describe 'with --template' do
+      it 'destroys template' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+
+          capture_io {
+            Lotus::Commands::Generate::Action.new({template: 'haml'}, 'web', 'books#index').start
+
+            Lotus::Commands::Generate::Action.new({template: 'haml'}, 'web', 'books#index').destroy.start
+          }
+
+          refute_file_exists('apps/web/templates/books/index.html.haml')
+        end
+      end
+    end
+  end
+
   def assert_generated_app_action(test_framework, original_wd)
     assert_generated_file(original_wd.join('test/fixtures/commands/generate/action/routes.get.rb'), 'config/routes.rb')
     assert_generated_file(original_wd.join("test/fixtures/commands/generate/action/action_spec.app.#{test_framework}.rb"), 'spec/controllers/books/index_spec.rb')

--- a/test/commands/generate/mailer_test.rb
+++ b/test/commands/generate/mailer_test.rb
@@ -82,6 +82,23 @@ describe Lotus::Commands::Generate::Mailer do
     end
   end
 
+  describe '#destroy' do
+    it 'destroys mailer and spec files' do
+      with_temp_dir do |original_wd|
+        capture_io {
+          Lotus::Commands::Generate::Mailer.new({}, 'ForgotPassword').start
+
+          Lotus::Commands::Generate::Mailer.new({}, 'ForgotPassword').destroy.start
+        }
+
+        refute_file_exists('lib/testapp/mailers/forgot_password.rb')
+        refute_file_exists('lib/testapp/mailers/templates/forgot_password.txt.erb')
+        refute_file_exists('lib/testapp/mailers/templates/forgot_password.html.erb')
+        refute_file_exists('spec/testapp/mailers/forgot_password_spec.rb')
+      end
+    end
+  end
+
   def assert_generated_mailer_and_spec(test, original_wd)
     assert_generated_file(original_wd.join('test/fixtures/commands/generate/mailer/forgot_password.rb'), 'lib/testapp/mailers/forgot_password.rb')
     assert_generated_file(original_wd.join('test/fixtures/commands/generate/mailer/forgot_password.txt.erb'), 'lib/testapp/mailers/templates/forgot_password.txt.erb')

--- a/test/commands/generate/migration_test.rb
+++ b/test/commands/generate/migration_test.rb
@@ -39,8 +39,32 @@ describe Lotus::Commands::Generate::Migration do
     end
   end
 
+  describe '#destroy' do
+    it 'destroys the migration file' do
+      with_temp_dir do |original_wd|
+        setup_app
+
+        capture_io {
+          Lotus::Commands::Generate::Migration.new({}, 'create_books').start
+
+          Lotus::Commands::Generate::Migration.new({}, 'create_users').start
+
+          Lotus::Commands::Generate::Migration.new({}, 'create_books').destroy.start
+        }
+
+        assert_migration_exists('create_users')
+
+        refute_migration_exists('create_books')
+      end
+    end
+  end
+
   def assert_migration_exists(name)
     assert Dir.glob("db/migrations/[0-9]*_#{name}.rb").any?, "Expected migration #{name} to exist but does not."
+  end
+
+  def refute_migration_exists(name)
+    refute Dir.glob("db/migrations/[0-9]*_#{name}.rb").any?, "Expected migration #{name} to NOT exist but does."
   end
 
   def setup_app

--- a/test/commands/generate/migration_test.rb
+++ b/test/commands/generate/migration_test.rb
@@ -20,9 +20,10 @@ describe Lotus::Commands::Generate::Migration do
         setup_app
         command = Lotus::Commands::Generate::Migration.new({}, 'something')
         capture_io { command.start }
-        files = Dir.glob('db/migrations/*_something.rb')
 
-        assert 1, files.size
+        assert_migration_exists('something')
+
+        files = Dir.glob('db/migrations/*_something.rb')
         assert_generated_file(original_wd.join('test/fixtures/commands/generate/migration/migration.rb'), files.first)
       end
     end
@@ -32,10 +33,14 @@ describe Lotus::Commands::Generate::Migration do
         setup_app
         command = Lotus::Commands::Generate::Migration.new({}, 'SoMe-Thing-Strange')
         capture_io { command.start }
-        files = Dir.glob('db/migrations/*_so_me_thing_strange.rb')
-        assert 1, files.size
+
+        assert_migration_exists('so_me_thing_strange')
       end
     end
+  end
+
+  def assert_migration_exists(name)
+    assert Dir.glob("db/migrations/[0-9]*_#{name}.rb").any?, "Expected migration #{name} to exist but does not."
   end
 
   def setup_app

--- a/test/commands/generate/model_test.rb
+++ b/test/commands/generate/model_test.rb
@@ -65,4 +65,22 @@ describe Lotus::Commands::Generate::Model do
       end
     end
   end
+
+  describe '#destroy' do
+    it 'destroys model, repository and spec files' do
+      with_temp_dir do |original_wd|
+        capture_io {
+          Lotus::Commands::Generate::Model.new({}, 'car').start
+
+          Lotus::Commands::Generate::Model.new({}, 'car').destroy.start
+        }
+
+        refute_file_exists('spec/testapp/repositories/car_repository_spec.rb')
+        refute_file_exists('spec/testapp/entities/car_spec.rb')
+        refute_file_exists('lib/testapp/entities/car.rb')
+        refute_file_exists('lib/testapp/repositories/car_repository.rb')
+      end
+    end
+  end
+
 end

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -44,5 +44,20 @@ module Minitest
         end
       end
     end
+
+    def refute_file_includes(expected, *contents)
+      assert_file_exists(expected)
+
+      read = File.read(expected)
+
+      contents.each do |content|
+        case content
+        when String
+          refute read.include?(content), "Expected #{read} to NOT include #{content} but does."
+        when Regexp
+          refute_match content, read
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Add destroy command to allow remove generated files and settings from
action, model, migrate and mailers generators.

The destroy is done by changing the behavior(Thor) of the generators
before they started to generate.

Also refactor cli generators and tests:
* Clean generators and tests.
* Removes some duplicated code.
* Applies `Generatable` role in generators to avoid code duplication and
make the code more consistent between generators.
* Add more file assertions to be used in the tests.