### PR TITLE
Fix the error uninitialized constant Lotus::VERSION of app generator

### DIFF
--- a/lib/lotus/commands/generate/abstract.rb
+++ b/lib/lotus/commands/generate/abstract.rb
@@ -1,5 +1,6 @@
 require 'lotus/environment'
 require 'lotus/generators/test_framework'
+require 'lotus/version'
 require 'thor'
 
 module Lotus


### PR DESCRIPTION
The error happens when generating a new app, because the lotus::VERSION is referenced by the generator templates and the constant is not available.

To fix the issue the module has required in the generators.

Aparently the error started after SHA: a52662fa5860b1fa8f03ff3b711d6782bbb2bd45

And the error did not show up in the tests, because the test_helper includes the required constant.