### PR TITLE
Loads Gemfile when running lotus server.

### DIFF
--- a/bin/lotus
+++ b/bin/lotus
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
 
+require 'lotus/setup'
 require 'lotus/cli'
 Lotus::Cli.start

--- a/lib/lotus/environment.rb
+++ b/lib/lotus/environment.rb
@@ -213,7 +213,7 @@ module Lotus
     #
     # @see http://bundler.io/v1.7/groups.html
     def bundler_groups
-      [environment]
+      [:default, environment]
     end
 
     # Application's root

--- a/lib/lotus/setup.rb
+++ b/lib/lotus/setup.rb
@@ -1,5 +1,3 @@
 require 'lotusrb'
 
-Bundler.require(
-  *Lotus::Environment.new.bundler_groups
-)
+Bundler.require(*Lotus::Environment.new.bundler_groups)

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -222,8 +222,9 @@ describe Lotus::Environment do
     end
 
     it 'returns a set of groups for Bundler' do
-      @env.bundler_groups.must_equal [@env.environment]
+      @env.bundler_groups.must_equal [:default, @env.environment]
     end
+
   end
 
   describe '#config' do

--- a/test/lotus_setup_test.rb
+++ b/test/lotus_setup_test.rb
@@ -11,13 +11,14 @@ describe 'lotus/setup' do
         Bundler = Module.new do
           extend self
 
-          def require(groups)
+          def require(*groups)
             @required_groups = groups
           end
 
           def required_groups
             @required_groups
           end
+
         end
       end
 
@@ -32,7 +33,8 @@ describe 'lotus/setup' do
 
     it 'requires Bundler groups' do
       env = Lotus::Environment.new
-      Bundler.required_groups.must_equal(*env.bundler_groups)
+      Bundler.required_groups.must_equal(env.bundler_groups)
     end
+
   end
 end


### PR DESCRIPTION
When running `lotus server` without `bundle exec`  it doesn't load the gemfile so it doesn't check for missing dependencies.

Example:

```
$ gem install lotusrb
$ lotus new bookshelf
$ cd bookshelf
$ gem uninstall lotus-model # removes a dependency
$ lotus server # without bundle exec
```

When I access `http://localhost:2300/` I got :
```
Boot Error

Something went wrong while loading /Users/lucas/Projetos/open-source/bookshelf/config.ru

SystemExit: exit

/Users/lucas/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/setup.rb:15:in `exit'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/setup.rb:15:in `rescue in <top (required)>'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/setup.rb:7:in `<top (required)>'
/Users/lucas/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:69:in `require'
/Users/lucas/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:69:in `require'
/Users/lucas/Projetos/open-source/bookshelf/config/environment.rb:2:in `<top (required)>'
/Users/lucas/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:121:in `require'
/Users/lucas/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:121:in `require'
/Users/lucas/Projetos/open-source/bookshelf/config.ru:1:in `block in inner_app'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/rack-1.6.4/lib/rack/builder.rb:55:in `instance_eval'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/rack-1.6.4/lib/rack/builder.rb:55:in `initialize'
/Users/lucas/Projetos/open-source/bookshelf/config.ru:1:in `new'
/Users/lucas/Projetos/open-source/bookshelf/config.ru:1:in `inner_app'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/shotgun-0.9.1/lib/shotgun/loader.rb:113:in `eval'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/shotgun-0.9.1/lib/shotgun/loader.rb:113:in `inner_app'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/shotgun-0.9.1/lib/shotgun/loader.rb:103:in `assemble_app'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/shotgun-0.9.1/lib/shotgun/loader.rb:86:in `proceed_as_child'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/shotgun-0.9.1/lib/shotgun/loader.rb:31:in `call!'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/shotgun-0.9.1/lib/shotgun/loader.rb:18:in `call'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/rack-1.6.4/lib/rack/lint.rb:49:in `_call'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/rack-1.6.4/lib/rack/lint.rb:37:in `call'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/rack-1.6.4/lib/rack/showexceptions.rb:24:in `call'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/rack-1.6.4/lib/rack/commonlogger.rb:33:in `call'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/rack-1.6.4/lib/rack/content_length.rb:15:in `call'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/puma-2.12.3/lib/puma/server.rb:541:in `handle_request'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/puma-2.12.3/lib/puma/server.rb:388:in `process_client'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/puma-2.12.3/lib/puma/server.rb:270:in `block in run'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/puma-2.12.3/lib/puma/thread_pool.rb:106:in `call'
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/puma-2.12.3/lib/puma/thread_pool.rb:106:in `block in spawn_thread'
```

Now with these changes, when running `lotus server` we get an exception:

```
$ lotus server
/Users/lucas/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/spec_set.rb:92:in `block in materialize': Could not find lotus-model-0.5.0 in any of the sources (Bundler::GemNotFound)
	from /Users/lucas/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/spec_set.rb:85:in `map!'
	from /Users/lucas/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/spec_set.rb:85:in `materialize'
	from /Users/lucas/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/definition.rb:140:in `specs'
	from /Users/lucas/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/definition.rb:185:in `specs_for'
	from /Users/lucas/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/runtime.rb:13:in `setup'
	from /Users/lucas/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler.rb:129:in `setup'
	from /Users/lucas/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler.rb:134:in `require'
	from /Users/lucas/.rvm/gems/ruby-2.2.2/gems/lotusrb-0.5.0/lib/lotus/setup.rb:3:in `<top (required)>'
	from /Users/lucas/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:69:in `require'
	from /Users/lucas/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:69:in `require'
	from /Users/lucas/.rvm/gems/ruby-2.2.2/gems/lotusrb-0.5.0/bin/lotus:3:in `<top (required)>'
	from /Users/lucas/.rvm/gems/ruby-2.2.2/bin/lotus:23:in `load'
	from /Users/lucas/.rvm/gems/ruby-2.2.2/bin/lotus:23:in `<main>'
	from /Users/lucas/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `eval'
	from /Users/lucas/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `<main>'
```