### PR TITLE
Totally refactored work with lotusrc

### DIFF
--- a/lib/lotus/commands/generate/abstract.rb
+++ b/lib/lotus/commands/generate/abstract.rb
@@ -29,7 +29,7 @@ module Lotus
         private
 
         def lotusrc_options
-          @lotusrc_options ||= Lotusrc.new(target_path).read
+          @lotusrc_options ||= Lotusrc.new(target_path).options
         end
 
         def environment

--- a/lib/lotus/environment.rb
+++ b/lib/lotus/environment.rb
@@ -173,7 +173,7 @@ module Lotus
     #   # the one defined in the parent (eg `FOO` is overwritten). All the
     #   # other settings (eg `XYZ`) will be left untouched.
     def initialize(options = {})
-      @options = Lotus::Lotusrc.new(root, options).read
+      @options = Lotus::Lotusrc.new(root).options
       @options.merge! Utils::Hash.new(options.clone).symbolize!
       @mutex   = Mutex.new
       @mutex.synchronize { set_env_vars! }

--- a/test/commands/generate/action_test.rb
+++ b/test/commands/generate/action_test.rb
@@ -325,15 +325,14 @@ describe Lotus::Commands::Generate::Action do
   end
 
   def setup_container_app
-    Lotus::Lotusrc.new(Pathname.new('.'), architecture: 'container')
-
+    File.open('.lotusrc', 'w') { |file| file << "architecture=container"}
     FileUtils.mkdir_p('apps/web') # simulate existing app
     FileUtils.mkdir_p('apps/web/config') # simulate existing routes file to see if route is prepended
     File.open('apps/web/config/routes.rb', 'w') { |file| file << "get '/cars', to: 'cars#index'"}
   end
 
   def setup_app_app
-    Lotus::Lotusrc.new(Pathname.new('.'), architecture: 'app')
+    File.open('.lotusrc', 'w') { |file| file << "architecture=app"}
     FileUtils.mkdir_p('app') # simulate existing app
     FileUtils.mkdir_p('config') # simulate existing routes file to see if route is prepended
     File.open('config/routes.rb', 'w') { |file| file << "get '/cars', to: 'cars#index'"}

--- a/test/commands/generate/app_test.rb
+++ b/test/commands/generate/app_test.rb
@@ -66,8 +66,7 @@ describe Lotus::Commands::Generate::App do
 
   it 'can not run for app architecture' do
     with_temp_dir do |original_wd|
-      Lotus::Lotusrc.new(Pathname.new('.'), architecture: 'app')
-
+      File.open('.lotusrc', 'w') { |file| file << "architecture=app"}
       -> { Lotus::Commands::Generate::App.new({}, 'admin') }.must_raise ArgumentError
     end
   end

--- a/test/lotusrc_test.rb
+++ b/test/lotusrc_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe Lotus::Lotusrc do
-  describe '#read' do
+  describe '#options' do
     describe 'file exists' do
       before do
         Dir.chdir($pwd)
@@ -15,17 +15,14 @@ describe Lotus::Lotusrc do
         Dir.chdir @old_pwd
       end
 
-      it 'get values in the file' do
-        options = @lotusrc.read
-        options[:architecture].must_equal 'container'
-        options[:test].must_equal 'minitest'
-        options[:template].must_equal 'erb'
+      describe "#exists?" do
+        it 'retuns true' do
+          Lotus::Lotusrc.new(@root).exists?.must_equal true
+        end
       end
 
-      it 'get values although arguments are passed' do
-        options = { architecture: 'application', test: 'rspec', template: 'slim' }
-        lotusrc = Lotus::Lotusrc.new(@root, options)
-        options = lotusrc.read
+      it 'get values in the file' do
+        options = @lotusrc.options
         options[:architecture].must_equal 'container'
         options[:test].must_equal 'minitest'
         options[:template].must_equal 'erb'
@@ -33,11 +30,13 @@ describe Lotus::Lotusrc do
 
       # Bug: https://github.com/lotus/lotus/issues/243
       it "doesn't pollute ENV" do
-        @lotusrc.read
-
         ENV.key?('architecture').must_equal false
         ENV.key?('test').must_equal false
         ENV.key?('template').must_equal false
+      end
+
+      it 'returns only environment options' do
+
       end
     end
 
@@ -53,42 +52,22 @@ describe Lotus::Lotusrc do
         Dir.chdir @old_pwd
       end
 
-      describe 'default values' do
-        before do
-          @file = Pathname.new(Dir.pwd).join('.lotusrc')
-          @lotusrc = Lotus::Lotusrc.new(@root)
-        end
-
-        after do
-          File.delete(@file)
-        end
-
-        it 'read the file' do
-          options = @lotusrc.read
-          options[:architecture].must_equal 'container'
-          options[:test].must_equal 'minitest'
-          options[:template].must_equal 'erb'
+      describe "#exists?" do
+        it 'retuns false' do
+          Lotus::Lotusrc.new(@root).exists?.must_equal false
         end
       end
 
-      describe 'custom values' do
+      describe 'default values' do
         before do
-          @file = Pathname.new(Dir.pwd).join('.lotusrc')
-          @file.unlink if @file.exist?
-
-          options = { architecture: 'application', test: 'rspec', template: 'slim' }
-          @lotusrc = Lotus::Lotusrc.new(@root, options)
+          @lotusrc = Lotus::Lotusrc.new(@root)
         end
 
-        after do
-          File.delete(@file)
-        end
-
-        it 'read the file' do
-          options = @lotusrc.read
-          options[:architecture].must_equal 'application'
-          options[:test].must_equal 'rspec'
-          options[:template].must_equal 'slim'
+        it 'reads the file' do
+          options = @lotusrc.options
+          options[:architecture].must_equal 'container'
+          options[:test].must_equal 'minitest'
+          options[:template].must_equal 'erb'
         end
       end
     end


### PR DESCRIPTION
__It's very urgent!!!__

Currently, every `lotus` command line generates `.lotusrc` file, even `lotus help`. The reason is https://github.com/lotus/lotus/blob/master/lib/lotus/setup.rb#L3.
 
More complex problem is that `Lotus::Lotusrc.new` generates this file ([prooflink](https://github.com/lotus/lotus/commit/cf6695e6a66bdd8e8f2fa5e83b11de432954819c#diff-00c8fc8ba6a42495f2a5f805f67e19faR76)) , although creation should be executed only on generation new application ([like this](https://github.com/lotus/lotus/commit/f80de2e7ae615a8348be7fc830f07ee907699860#diff-bad57f74cb2621a0a3d2d6e390ac7aa9R41)).

I propose to detect `lotusrc` existance, if no then use [default options](https://github.com/lotus/lotus/compare/lotus:master...aderyabin:double_lotusrc?expand=1#diff-00c8fc8ba6a42495f2a5f805f67e19faR72)

It should resolve #369 