### PR TITLE
RSpec disable_monkey_patching! mode compatibility

### DIFF
--- a/lib/lotus/generators/action/action_spec.rspec.tt
+++ b/lib/lotus/generators/action/action_spec.rspec.tt
@@ -1,6 +1,6 @@
 require_relative '<%= config[:relative_action_path] %>'
 
-describe <%= config[:app] %>::Controllers::<%= config[:controller] %>::<%= config[:action] %> do
+RSpec.describe <%= config[:app] %>::Controllers::<%= config[:controller] %>::<%= config[:action] %> do
   let(:action) { described_class.new }
   let(:params) { Hash[] }
 

--- a/lib/lotus/generators/action/view_spec.rspec.tt
+++ b/lib/lotus/generators/action/view_spec.rspec.tt
@@ -1,6 +1,6 @@
 require_relative '<%= config[:relative_view_path] %>'
 
-describe <%= config[:app] %>::Views::<%= config[:controller] %>::<%= config[:action] %> do
+RSpec.describe <%= config[:app] %>::Views::<%= config[:controller] %>::<%= config[:action] %> do
   let(:exposures) { Hash[foo: 'bar'] }
   let(:template)  { Lotus::View::Template.new('<%= config[:template_path] %>') }
   let(:view)      { described_class.new(template, exposures) }

--- a/test/fixtures/commands/generate/action/action_spec.app.rspec.rb
+++ b/test/fixtures/commands/generate/action/action_spec.app.rspec.rb
@@ -1,6 +1,6 @@
 require_relative '../../../app/controllers/books/index'
 
-describe Testapp::Controllers::Books::Index do
+RSpec.describe Testapp::Controllers::Books::Index do
   let(:action) { described_class.new }
   let(:params) { Hash[] }
 

--- a/test/fixtures/commands/generate/action/action_spec.container.rspec.rb
+++ b/test/fixtures/commands/generate/action/action_spec.container.rspec.rb
@@ -1,6 +1,6 @@
 require_relative '../../../../apps/web/controllers/books/index'
 
-describe Web::Controllers::Books::Index do
+RSpec.describe Web::Controllers::Books::Index do
   let(:action) { described_class.new }
   let(:params) { Hash[] }
 

--- a/test/fixtures/commands/generate/action/view_spec.app.rspec.rb
+++ b/test/fixtures/commands/generate/action/view_spec.app.rspec.rb
@@ -1,6 +1,6 @@
 require_relative '../../../app/views/books/index'
 
-describe Testapp::Views::Books::Index do
+RSpec.describe Testapp::Views::Books::Index do
   let(:exposures) { Hash[foo: 'bar'] }
   let(:template)  { Lotus::View::Template.new('app/templates/books/index.html.erb') }
   let(:view)      { described_class.new(template, exposures) }

--- a/test/fixtures/commands/generate/action/view_spec.container.rspec.rb
+++ b/test/fixtures/commands/generate/action/view_spec.container.rspec.rb
@@ -1,6 +1,6 @@
 require_relative '../../../../apps/web/views/books/index'
 
-describe Web::Views::Books::Index do
+RSpec.describe Web::Views::Books::Index do
   let(:exposures) { Hash[foo: 'bar'] }
   let(:template)  { Lotus::View::Template.new('apps/web/templates/books/index.html.erb') }
   let(:view)      { described_class.new(template, exposures) }


### PR DESCRIPTION
RSpec has introduced with 3.0 a mode to avoid to monkey-patching. It's a configuration disabled by default (see https://www.relishapp.com/rspec/rspec-core/v/3-0/docs/configuration/zero-monkey-patching-mode).

This PR makes our generated specs for actions and views to play well with it.

Actual:

```ruby
describe ... do
end
```

Wanted:

```ruby
RSpec.describe do
end
```

/cc @lotus/core-team 