### PR TITLE
Fix bug where lotus port can not be set from .env

### DIFF
--- a/lib/lotus/environment.rb
+++ b/lib/lotus/environment.rb
@@ -418,8 +418,8 @@ module Lotus
     # @since 0.1.0
     # @api private
     def set_env_vars!
-      set_lotus_env_vars!
       set_application_env_vars!
+      set_lotus_env_vars!
     end
 
     # @since 0.2.0

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -27,6 +27,10 @@ describe Lotus::Environment do
         ENV['FOO'].must_equal 'bar'
       end
 
+      it 'sets port from .env' do
+        @env.port.must_equal 42
+      end
+
       it 'sets env vars from the environment .env' do
         ENV['BAZ'].must_equal 'yes' # override
         ENV['WAT'].must_equal 'true'

--- a/test/fixtures/.env
+++ b/test/fixtures/.env
@@ -1,2 +1,3 @@
 FOO="bar"
 BAZ="no"
+LOTUS_PORT=42


### PR DESCRIPTION
This PR contains two commits, one introducing a test that demonstrates the bug, and the commit fixing this bug.

