### PR TITLE
Timing

### DIFF
--- a/lib/lotus/action/csrf_protection.rb
+++ b/lib/lotus/action/csrf_protection.rb
@@ -129,7 +129,7 @@ module Lotus
       # @api private
       def invalid_csrf_token?
         verify_csrf_token? &&
-          session[CSRF_TOKEN] != params[CSRF_TOKEN]
+          Rack::Utils.secure_compare(session[CSRF_TOKEN], params[CSRF_TOKEN])
       end
 
       # Generates a random CSRF Token

--- a/lib/lotus/action/csrf_protection.rb
+++ b/lib/lotus/action/csrf_protection.rb
@@ -129,7 +129,7 @@ module Lotus
       # @api private
       def invalid_csrf_token?
         verify_csrf_token? &&
-          Rack::Utils.secure_compare(session[CSRF_TOKEN], params[CSRF_TOKEN])
+          ! ::Rack::Utils.secure_compare(session[CSRF_TOKEN], params[CSRF_TOKEN])
       end
 
       # Generates a random CSRF Token


### PR DESCRIPTION
While network timing attacks are not trivial, using secure_compare will ensure they can't happen.

See https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L318 for prior art.

No tests since this change should be transparent. Creating a timing attack PoC for a test seems like a terrible idea. Existing tests pass.