### PR TITLE
Automatically use correct HTTP verbs for resourceful routes

### DIFF
--- a/lib/lotus/commands/generate/action.rb
+++ b/lib/lotus/commands/generate/action.rb
@@ -23,6 +23,15 @@ module Lotus
         # @api private
         DEFAULT_HTTP_METHOD = 'GET'.freeze
 
+        # HTTP methods used when generating resourceful actions.
+        # @since x.x.x
+        # @api private
+        RESOURCEFUL_HTTP_METHODS =  {
+          "Create" => "POST",
+          "Update" => "PATCH",
+          "Destroy" => "DELETE"
+        }.freeze
+
         def initialize(options, application_name, controller_and_action_name)
           super(options)
           if !environment.container?
@@ -92,7 +101,13 @@ module Lotus
         # @since x.x.x
         # @api private
         def http_method
-          options.fetch(:method, DEFAULT_HTTP_METHOD).downcase
+          options.fetch(:method, resourceful_http_method).downcase
+        end
+
+        # @since x.x.x
+        # @api private
+        def resourceful_http_method
+          RESOURCEFUL_HTTP_METHODS.fetch(@action_name, DEFAULT_HTTP_METHOD)
         end
 
         # @since x.x.x

--- a/test/commands/generate/action_test.rb
+++ b/test/commands/generate/action_test.rb
@@ -98,6 +98,48 @@ describe Lotus::Commands::Generate::Action do
       end
     end
 
+    describe 'resourceful HTTP default methods' do
+      it 'uses POST for "create" action' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+          command = Lotus::Commands::Generate::Action.new({}, 'web', 'books/create')
+          capture_io { command.start }
+
+          assert_file_includes('apps/web/config/routes.rb', "post '/books', to: 'books#create'")
+        end
+      end
+
+      it 'uses PATCH for "update" action' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+          command = Lotus::Commands::Generate::Action.new({}, 'web', 'books/update')
+          capture_io { command.start }
+
+          assert_file_includes('apps/web/config/routes.rb', "patch '/books', to: 'books#update'")
+        end
+      end
+
+      it 'uses DELETE for "destroy" action' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+          command = Lotus::Commands::Generate::Action.new({}, 'web', 'books/destroy')
+          capture_io { command.start }
+
+          assert_file_includes('apps/web/config/routes.rb', "delete '/books', to: 'books#destroy'")
+        end
+      end
+
+      it 'does not override user specified http method' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+          command = Lotus::Commands::Generate::Action.new({method: 'get'}, 'web', 'books/create')
+          capture_io { command.start }
+
+          assert_file_includes('apps/web/config/routes.rb', "get '/books', to: 'books#create'")
+        end
+      end
+    end
+
     describe 'container architecture' do
       describe 'with minitest' do
         it 'generates the files' do


### PR DESCRIPTION
In the the router, we have [RESTful Resources](http://lotusrb.org/guides/routing/restful-resources/).

This PR updates the action generator to automatically set the proper HTTP methods for actions named `create`, `update` and `destroy` (i.e. `POST`, `PATCH` and `DELETE`). I don't suggest we try to guess any others, but since these are used in `resources` they're okay in my opinion.

(A user provided `--method` still overrides this)

If this PR is accepted, I'll update the [`getting-started.md` guide](https://github.com/lotus/lotus.github.io/search?p=2&q=default&type=Code&utf8=%E2%9C%93) as well.