### PR TITLE
Add video tag helper

### DIFF
--- a/lib/lotus/helpers/asset_tag_helpers.rb
+++ b/lib/lotus/helpers/asset_tag_helpers.rb
@@ -40,6 +40,69 @@ module Lotus
       def asset_path(source)
         "/assets/#{source}" # To be implemented
       end
+
+      # Generates a video tag for the given arguments.
+      #
+      # @raise [ArgumentError] if the signature isn't respected
+      # @since x.x.x
+      # @api public
+      #
+      # @example Basic usage
+      #   <%= video('movie.mp4') %>
+      #     # => <video src="/assets/movie.mp4"></video>
+      #
+      # @example HTML attributes
+      #   <%= video('movie.mp4', autoplay: true, controls: true) %>
+      #     # => <video src="/assets/movie.mp4" autoplay="autoplay" controls="controls"></video>
+      #
+      # @example Fallback Content
+      #   <%=
+      #     video('movie.mp4') do
+      #       "Your browser does not support the video tag"
+      #     end
+      #   %>
+      #     # => <video src="/assets/movie.mp4">\nYour browser does not support the video tag\n</video>
+      #
+      # @example Tracks
+      #   <%=
+      #     video('movie.mp4') do
+      #       track kind: 'captions', src: view.asset_path('movie.en.vtt'), srclang: 'en', label: 'English'
+      #     end
+      #   %>
+      #     # => <video src="/assets/movie.mp4">\n<track kind="captions" src="/assets/movie.en.vtt" srclang="en" label="English">\n</video>
+      #
+      # @example Sources
+      #   <%=
+      #     video do
+      #       text "Your browser does not support the video tag"
+      #       source src: view.asset_path('movie.mp4'), type: 'video/mp4'
+      #       source src: view.asset_path('movie.ogg'), type: 'video/ogg'
+      #     end
+      #   %>
+      #     # => <video>\nYour browser does not support the video tag\n<source src="/assets/movie.mp4" type="video/mp4">\n<source src="/assets/movie.ogg" type="video/ogg">\n</video>
+      #
+      # @example Without any argument
+      #   <%= video %>
+      #     # => ArgumentError
+      #
+      # @example Without src and without block
+      #   <%= video(content: true) %>
+      #     # => ArgumentError
+      def video(src = nil, options = {}, &blk)
+        options ||= {}
+
+        if src.respond_to?(:to_hash)
+          options = src.to_hash
+        elsif src
+          options[:src] = asset_path(src)
+        end
+
+        if !options[:src] && !block_given?
+          raise ArgumentError.new('You should provide a source via `src` option or with a `source` HTML tag')
+        end
+
+        html.video(blk, options)
+      end
     end
   end
 end

--- a/test/fixtures/collaboration/apps/web/app/templates/assets/index.html.erb
+++ b/test/fixtures/collaboration/apps/web/app/templates/assets/index.html.erb
@@ -1,1 +1,9 @@
 <%= image('application.jpg') %>
+<%= video('movie.mp4') %>
+<%=
+video do
+  text "Your browser does not support the video tag"
+  source src: view.asset_path('movie.mp4'), type: 'video/mp4'
+  source src: view.asset_path('movie.ogg'), type: 'video/ogg'
+end
+%>

--- a/test/helpers/asset_tag_helpers_test.rb
+++ b/test/helpers/asset_tag_helpers_test.rb
@@ -27,4 +27,47 @@ describe Lotus::Helpers::AssetTagHelpers do
       view.image('application.jpg', 'data-user-id' => 5).to_s.must_equal %(<img data-user-id=\"5\" src=\"/assets/application.jpg\" alt=\"Application\">)
     end
   end
+
+  describe '#video' do
+    it 'renders' do
+      tag = view.video('movie.mp4')
+      tag.to_s.must_equal %(<video src="/assets/movie.mp4"></video>)
+    end
+
+    it 'renders with html attributes' do
+      tag = view.video('movie.mp4', autoplay: true, controls: true)
+      tag.to_s.must_equal %(<video autoplay="autoplay" controls="controls" src="/assets/movie.mp4"></video>)
+    end
+
+    it 'renders with fallback content' do
+      tag = view.video('movie.mp4') do
+        "Your browser does not support the video tag"
+      end
+      tag.to_s.must_equal %(<video src="/assets/movie.mp4">\nYour browser does not support the video tag\n</video>)
+    end
+
+    it 'renders with tracks' do
+      tag = view.video('movie.mp4') do
+        track kind: 'captions', src: view.asset_path('movie.en.vtt'), srclang: 'en', label: 'English'
+      end
+      tag.to_s.must_equal %(<video src="/assets/movie.mp4">\n<track kind="captions" src="/assets/movie.en.vtt" srclang="en" label="English">\n</video>)
+    end
+
+    it 'renders with sources' do
+      tag = view.video do
+        text "Your browser does not support the video tag"
+        source src: view.asset_path('movie.mp4'), type: 'video/mp4'
+        source src: view.asset_path('movie.ogg'), type: 'video/ogg'
+      end
+      tag.to_s.must_equal %(<video>\nYour browser does not support the video tag\n<source src="/assets/movie.mp4" type="video/mp4">\n<source src="/assets/movie.ogg" type="video/ogg">\n</video>)
+    end
+
+    it 'raises an exception when no arguments' do
+      -> {view.video()}.must_raise ArgumentError
+    end
+
+    it 'raises an exception when no src and no block' do
+      -> {view.video(content: true)}.must_raise ArgumentError
+    end
+  end
 end

--- a/test/integration/asset_helpers_test.rb
+++ b/test/integration/asset_helpers_test.rb
@@ -30,5 +30,23 @@ describe '' do
       response.body.must_include "<img src=\"/assets/application.jpg\" alt=\"Application\">"
     end
   end
+
+  describe 'video helper' do
+    it 'renders a video tag' do
+      get "/assets"
+
+      response.status.must_equal 200
+
+      response.body.must_include "<video src=\"/assets/movie.mp4\"></video>"
+    end
+
+    it 'renders a video tag with source tags' do
+      get "/assets"
+
+      response.status.must_equal 200
+
+      response.body.must_include %(<video>\nYour browser does not support the video tag\n<source src="/assets/movie.mp4" type="video/mp4">\n<source src="/assets/movie.ogg" type="video/ogg">\n</video>)
+    end
+  end
 end
 


### PR DESCRIPTION
https://github.com/lotus/lotus/issues/396

This commit exposes a `video` method to the view
which can be used to generate HTML5 video tags.
It accepts options to generate HTML attributes along
with a block for creating fallback content and/or
`source` and `track` tags.