### PR TITLE
Create resourceful routes for generated actions

### DIFF
--- a/lib/lotus/commands/generate/action.rb
+++ b/lib/lotus/commands/generate/action.rb
@@ -32,6 +32,17 @@ module Lotus
           "Destroy" => "DELETE"
         }.freeze
 
+        # For resourceful actions, what to add to the end of the base URL
+        # @since x.x.x
+        # @api private
+        RESOURCEFUL_ROUTE_URL_SUFFIXES = {
+          "Show" => "/:id",
+          "Update" => "/:id",
+          "Destroy" => "/:id",
+          "New" => "/new",
+          "Edit" => "/:id/edit",
+        }
+
         def initialize(options, application_name, controller_and_action_name)
           super(options)
           if !environment.container?
@@ -113,7 +124,13 @@ module Lotus
         # @since x.x.x
         # @api private
         def route_url
-          options.fetch(:url, "/#{ @controller_pathname }")
+          options.fetch(:url, "/#{ @controller_pathname }#{resourceful_route_url_suffix}")
+        end
+
+        # @since x.x.x
+        # @api private
+        def resourceful_route_url_suffix
+          RESOURCEFUL_ROUTE_URL_SUFFIXES.fetch(@action_name, "")
         end
 
         # @since x.x.x

--- a/test/commands/generate/action_test.rb
+++ b/test/commands/generate/action_test.rb
@@ -98,8 +98,38 @@ describe Lotus::Commands::Generate::Action do
       end
     end
 
-    describe 'resourceful HTTP default methods' do
-      it 'uses POST for "create" action' do
+    describe 'RESTful resource routes' do
+      it 'makes `index` route' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+          command = Lotus::Commands::Generate::Action.new({}, 'web', 'books/index')
+          capture_io { command.start }
+
+          assert_file_includes('apps/web/config/routes.rb', "get '/books', to: 'books#index")
+        end
+      end
+
+      it 'makes `show` route' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+          command = Lotus::Commands::Generate::Action.new({}, 'web', 'books/show')
+          capture_io { command.start }
+
+          assert_file_includes('apps/web/config/routes.rb', "get '/books/:id', to: 'books#show'")
+        end
+      end
+
+      it 'makes `new` route' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+          command = Lotus::Commands::Generate::Action.new({}, 'web', 'books/new')
+          capture_io { command.start }
+
+          assert_file_includes('apps/web/config/routes.rb', "get '/books/new', to: 'books#new'")
+        end
+      end
+
+      it 'makes `create` route' do
         with_temp_dir do |original_wd|
           setup_container_app
           command = Lotus::Commands::Generate::Action.new({}, 'web', 'books/create')
@@ -109,33 +139,53 @@ describe Lotus::Commands::Generate::Action do
         end
       end
 
-      it 'uses PATCH for "update" action' do
+      it 'makes `edit` route' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+          command = Lotus::Commands::Generate::Action.new({}, 'web', 'books/edit')
+          capture_io { command.start }
+
+          assert_file_includes('apps/web/config/routes.rb', "get '/books/:id/edit', to: 'books#edit'")
+        end
+      end
+
+      it 'makes `update` route' do
         with_temp_dir do |original_wd|
           setup_container_app
           command = Lotus::Commands::Generate::Action.new({}, 'web', 'books/update')
           capture_io { command.start }
 
-          assert_file_includes('apps/web/config/routes.rb', "patch '/books', to: 'books#update'")
+          assert_file_includes('apps/web/config/routes.rb', "patch '/books/:id', to: 'books#update'")
         end
       end
 
-      it 'uses DELETE for "destroy" action' do
+      it 'makes `destroy`' do
         with_temp_dir do |original_wd|
           setup_container_app
           command = Lotus::Commands::Generate::Action.new({}, 'web', 'books/destroy')
           capture_io { command.start }
 
-          assert_file_includes('apps/web/config/routes.rb', "delete '/books', to: 'books#destroy'")
+          assert_file_includes('apps/web/config/routes.rb', "delete '/books/:id', to: 'books#destroy'")
         end
       end
 
       it 'does not override user specified http method' do
         with_temp_dir do |original_wd|
           setup_container_app
-          command = Lotus::Commands::Generate::Action.new({method: 'get'}, 'web', 'books/create')
+          command = Lotus::Commands::Generate::Action.new({method: 'get'}, 'web', 'books/destroy')
           capture_io { command.start }
 
-          assert_file_includes('apps/web/config/routes.rb', "get '/books', to: 'books#create'")
+          assert_file_includes('apps/web/config/routes.rb', "get '/books/:id', to: 'books#destroy'")
+        end
+      end
+
+      it 'does not override user specified URL' do
+        with_temp_dir do |original_wd|
+          setup_container_app
+          command = Lotus::Commands::Generate::Action.new({url: '/books'}, 'web', 'books/destroy')
+          capture_io { command.start }
+
+          assert_file_includes('apps/web/config/routes.rb', "delete '/books', to: 'books#destroy'")
         end
       end
     end


### PR DESCRIPTION
Expands on #404 to generate Resourceful routes for generated actions.

So

`lotus generate action web books#new`

will generate:

`get '/books/new', to: 'books#new'`

rather than 

`get '/books', to: 'books#new'`
etc.

Based on [the conventions](http://lotusrb.org/guides/routing/restful-resources/).

Let me know if you want me to take a different approach. I could make the route `resource :books, only: [:new]` instead, though that'd get messy after a few generated actions for the same resource, since we just pre-pend to routes, we don't read it for current state.

Do I need to do anything with the `named_route`, for the URL helpers?