### PR TITLE
Added attributes option when generate a model

### DIFF
--- a/lib/lotus/cli_sub_commands/generate.rb
+++ b/lib/lotus/cli_sub_commands/generate.rb
@@ -67,8 +67,11 @@ module Lotus
 
         > $ lotus generate model car
 
+        > $ lotus generate model car --attributes=brand,model
+
         > $ lotus generate model vehicles/car
       EOS
+      method_option :attributes, desc: 'Defines attributes for the generated model'
       method_option :test, desc: 'Defines the testing Framework to be used. Default is defined through your .lotusrc file.'
       def model(name)
         if options[:help]

--- a/lib/lotus/commands/generate/model.rb
+++ b/lib/lotus/commands/generate/model.rb
@@ -5,17 +5,19 @@ module Lotus
     class Generate
       class Model < Abstract
 
-        attr_reader :model_name
+        attr_reader :model_name, :model_attributes
 
         def initialize(options, model_name)
           super(options)
-          @model_name = Utils::String.new(model_name).classify
+
+          @model_attributes = options[:attributes]
+          @model_name       = Utils::String.new(model_name).classify
 
           assert_model_name!
         end
 
         def map_templates
-          add_mapping('entity.rb.tt', entity_path)
+          add_mapping(entity_mapping_file, entity_path)
           add_mapping('repository.rb.tt', repository_path)
           add_mapping("entity_spec.#{ test_framework.framework }.tt", entity_spec_path,)
           add_mapping("repository_spec.#{ test_framework.framework }.tt", repository_spec_path)
@@ -23,11 +25,16 @@ module Lotus
 
         def template_options
           {
-            model_name: model_name
+            model_name: model_name,
+            model_attributes: model_attributes
           }
         end
 
         private
+
+        def entity_mapping_file
+          model_attributes ? 'entity_with_attributes.rb.tt' : 'entity.rb.tt'
+        end
 
         # @since x.x.x
         # @api private

--- a/lib/lotus/generators/model/entity_with_attributes.rb.tt
+++ b/lib/lotus/generators/model/entity_with_attributes.rb.tt
@@ -1,0 +1,5 @@
+class <%= config[:model_name] %>
+  include Lotus::Entity
+
+  <%= config[:model_attributes].split(",").map { |a| ":#{a}"}.join(", ").prepend("attributes ") if config[:model_attributes] %>
+end

--- a/test/commands/generate/model_test.rb
+++ b/test/commands/generate/model_test.rb
@@ -33,33 +33,48 @@ describe Lotus::Commands::Generate::Model do
         assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car.rb'), 'lib/testapp/entities/car.rb')
       end
     end
-
   end
 
   describe 'with valid arguments' do
-    describe 'with rspec' do
-      it 'creates model, repository and spec files' do
-        with_temp_dir do |original_wd|
-          command = Lotus::Commands::Generate::Model.new({'test' => 'rspec'}, 'car')
-          capture_io { command.start }
+    describe `test option` do
+      describe 'with rspec' do
+        it 'creates model, repository and spec files' do
+          with_temp_dir do |original_wd|
+            command = Lotus::Commands::Generate::Model.new({'test' => 'rspec'}, 'car')
+            capture_io { command.start }
 
-          assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car_repository_spec.rspec.rb'), 'spec/testapp/repositories/car_repository_spec.rb')
-          assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car_spec.rspec.rb'), 'spec/testapp/entities/car_spec.rb')
-          assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car.rb'), 'lib/testapp/entities/car.rb')
-          assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car_repository.rb'), 'lib/testapp/repositories/car_repository.rb')
+            assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car_repository_spec.rspec.rb'), 'spec/testapp/repositories/car_repository_spec.rb')
+            assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car_spec.rspec.rb'), 'spec/testapp/entities/car_spec.rb')
+            assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car.rb'), 'lib/testapp/entities/car.rb')
+            assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car_repository.rb'), 'lib/testapp/repositories/car_repository.rb')
+          end
+        end
+      end
+
+      describe 'with minitest' do
+        it 'creates model, repository and spec files' do
+          with_temp_dir do |original_wd|
+            command = Lotus::Commands::Generate::Model.new({}, 'car')
+            capture_io { command.start }
+
+            assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car_repository_spec.minitest.rb'), 'spec/testapp/repositories/car_repository_spec.rb')
+            assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car_spec.minitest.rb'), 'spec/testapp/entities/car_spec.rb')
+            assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car.rb'), 'lib/testapp/entities/car.rb')
+            assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car_repository.rb'), 'lib/testapp/repositories/car_repository.rb')
+          end
         end
       end
     end
 
-    describe 'with minitest' do
+    describe 'attributes option' do
       it 'creates model, repository and spec files' do
         with_temp_dir do |original_wd|
-          command = Lotus::Commands::Generate::Model.new({}, 'car')
+          command = Lotus::Commands::Generate::Model.new({'attributes' => 'brand,model'}, 'car')
           capture_io { command.start }
 
           assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car_repository_spec.minitest.rb'), 'spec/testapp/repositories/car_repository_spec.rb')
           assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car_spec.minitest.rb'), 'spec/testapp/entities/car_spec.rb')
-          assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car.rb'), 'lib/testapp/entities/car.rb')
+          assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car_with_attributes.rb'), 'lib/testapp/entities/car.rb')
           assert_generated_file(original_wd.join('test/fixtures/commands/generate/model/car_repository.rb'), 'lib/testapp/repositories/car_repository.rb')
         end
       end
@@ -82,5 +97,4 @@ describe Lotus::Commands::Generate::Model do
       end
     end
   end
-
 end

--- a/test/fixtures/commands/generate/model/car_with_attributes.rb
+++ b/test/fixtures/commands/generate/model/car_with_attributes.rb
@@ -1,0 +1,5 @@
+class Car
+  include Lotus::Entity
+
+  attributes :brand, :model
+end


### PR DESCRIPTION
This PR introduces a new option when you generate a model
```
lotus generate model car --attributes=brand,model
```
This command creates a file like this:
```ruby
class Car
  include Lotus::entity
 
  attributes :brand, :model
end