### PR TITLE
[WIP] Remove app naming prefix for DATABASE_URL unix env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Lotus
 A complete web framework for Ruby
 
+## v0.7.0 - (unreleased)
+### Added
+
+### Fixed
+
+### Changed
+- [Trung Lê] Removed the app naming prefix from generated DATABASE_URL env variable from `.env.*` files
+
 ## v0.6.0 - (unreleased)
 ### Added
-- [Trung Lê] Removed the app naming prefix from generated DATABASE_URL env variable from `.env.*` files
 - [Luca Guidi] Introduced "CDN mode" in order to serve static assets via Content Distribution Networks
 - [Luca Guidi] Introduced "Digest mode" in production in order to generate and serve assets with checksum suffix
 - [Luca Guidi] Introduced `lotus assets precompile` command to precompile, minify and append checksum suffix to static assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ A complete web framework for Ruby
 
 ## v0.6.0 - (unreleased)
 ### Added
+- [Trung Lê] Removed the app naming prefix from generated DATABASE_URL env variable from `.env.*` files
 - [Luca Guidi] Introduced "CDN mode" in order to serve static assets via Content Distribution Networks
 - [Luca Guidi] Introduced "Digest mode" in production in order to generate and serve assets with checksum suffix
 - [Luca Guidi] Introduced `lotus assets precompile` command to precompile, minify and append checksum suffix to static assets

--- a/lib/lotus/generators/application/app/.env.development.tt
+++ b/lib/lotus/generators/application/app/.env.development.tt
@@ -1,4 +1,4 @@
 # Define ENV variables for development environment
-<%= config[:upcase_app_name] %>_DATABASE_URL="<%= config[:database_config][:uri][:development] %>"
+DATABASE_URL="<%= config[:database_config][:uri][:development] %>"
 <%= config[:upcase_app_name] %>_SESSIONS_SECRET="<%= SecureRandom.hex(32) %>"
 SERVE_STATIC_ASSETS="true"

--- a/lib/lotus/generators/application/app/.env.test.tt
+++ b/lib/lotus/generators/application/app/.env.test.tt
@@ -1,4 +1,4 @@
 # Define ENV variables for test environment
-<%= config[:app_name].to_env_s %>_DATABASE_URL="<%= config[:database_config][:uri][:test] %>"
+DATABASE_URL="<%= config[:database_config][:uri][:test] %>"
 <%= config[:upcase_app_name] %>_SESSIONS_SECRET="<%= SecureRandom.hex(32) %>"
 SERVE_STATIC_ASSETS="true"

--- a/lib/lotus/generators/application/app/lib/app_name.rb.tt
+++ b/lib/lotus/generators/application/app/lib/app_name.rb.tt
@@ -15,7 +15,7 @@ Lotus::Model.configure do
   #    adapter type: :sql, uri: 'postgres://localhost/<%= config[:app_name] %>_development'
   #    adapter type: :sql, uri: 'mysql://localhost/<%= config[:app_name] %>_development'
   #
-  adapter type: :<%= config[:database_config][:type] %>, uri: ENV['<%= config[:app_name].to_env_s %>_DATABASE_URL']
+  adapter type: :<%= config[:database_config][:type] %>, uri: ENV['DATABASE_URL']
 
   <%- if config[:database_config][:type] == :sql -%>
   ##

--- a/lib/lotus/generators/application/container/.env.development.tt
+++ b/lib/lotus/generators/application/container/.env.development.tt
@@ -1,3 +1,3 @@
 # Define ENV variables for development environment
-<%= config[:app_name].to_env_s %>_DATABASE_URL="<%= config[:database_config][:uri][:development] %>"
+DATABASE_URL="<%= config[:database_config][:uri][:development] %>"
 SERVE_STATIC_ASSETS="true"

--- a/lib/lotus/generators/application/container/.env.test.tt
+++ b/lib/lotus/generators/application/container/.env.test.tt
@@ -1,3 +1,3 @@
 # Define ENV variables for test environment
-<%= config[:app_name].to_env_s %>_DATABASE_URL="<%= config[:database_config][:uri][:test] %>"
+DATABASE_URL="<%= config[:database_config][:uri][:test] %>"
 SERVE_STATIC_ASSETS="true"

--- a/lib/lotus/generators/application/container/lib/app_name.rb.tt
+++ b/lib/lotus/generators/application/container/lib/app_name.rb.tt
@@ -16,7 +16,7 @@ Lotus::Model.configure do
   #    adapter type: :sql, uri: 'postgres://localhost/<%= config[:app_name] %>_development'
   #    adapter type: :sql, uri: 'mysql://localhost/<%= config[:app_name] %>_development'
   #
-  adapter type: :<%= config[:database_config][:type] %>, uri: ENV['<%= config[:app_name].to_env_s %>_DATABASE_URL']
+  adapter type: :<%= config[:database_config][:type] %>, uri: ENV['DATABASE_URL']
 
   <%- if config[:database_config][:type] == :sql -%>
   ##

--- a/test/commands/new/app_test.rb
+++ b/test/commands/new/app_test.rb
@@ -63,12 +63,12 @@ describe Lotus::Commands::New::App do
       assert_generated_file(fixture_root.join('.env'), '.env')
 
       assert_file_includes('.env.development',
-                           'NEW_APP_DATABASE_URL="file:///db/new_app_development"',
+                           'DATABASE_URL="file:///db/new_app_development"',
                            'SERVE_STATIC_ASSETS="true"',
                            %r{NEW_APP_SESSIONS_SECRET="[\w]{64}"})
 
       assert_file_includes('.env.test',
-                           'NEW_APP_DATABASE_URL="file:///db/new_app_test"',
+                           'DATABASE_URL="file:///db/new_app_test"',
                            'SERVE_STATIC_ASSETS="true"',
                            %r{NEW_APP_SESSIONS_SECRET="[\w]{64}"})
 

--- a/test/fixtures/commands/application/new_app/lib/new_app.rb
+++ b/test/fixtures/commands/application/new_app/lib/new_app.rb
@@ -15,7 +15,7 @@ Lotus::Model.configure do
   #    adapter type: :sql, uri: 'postgres://localhost/new_app_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_app_development'
   #
-  adapter type: :file_system, uri: ENV['NEW_APP_DATABASE_URL']
+  adapter type: :file_system, uri: ENV['DATABASE_URL']
 
   ##
   # Database mapping

--- a/test/integration/cli/database_test.rb
+++ b/test/integration/cli/database_test.rb
@@ -28,19 +28,19 @@ describe 'lotus db' do
 
     File.open(root.join('.env.development'), 'w') do |f|
       f.write <<-DOTENV
-#{ app_name.upcase }_DATABASE_URL="#{ adapter_prefix }sqlite://#{ root.join("db/#{ app_name }_development.sqlite3") }"
+DATABASE_URL="#{ adapter_prefix }sqlite://#{ root.join("db/#{ app_name }_development.sqlite3") }"
       DOTENV
     end
 
     File.open(root.join('.env.test'), 'w') do |f|
       f.write <<-DOTENV
-#{ app_name.upcase }_DATABASE_URL="#{ adapter_prefix }sqlite://#{ root.join("db/#{ app_name }_test.sqlite3") }"
+DATABASE_URL="#{ adapter_prefix }sqlite://#{ root.join("db/#{ app_name }_test.sqlite3") }"
       DOTENV
     end
 
     File.open(root.join('.env'), 'w') do |f|
       f.write <<-DOTENV
-#{ app_name.upcase }_DATABASE_URL="#{ adapter_prefix }sqlite://#{ root.join("db/#{ app_name }.sqlite3") }"
+DATABASE_URL="#{ adapter_prefix }sqlite://#{ root.join("db/#{ app_name }.sqlite3") }"
       DOTENV
     end
 


### PR DESCRIPTION
Why?

It would make the unix var much more friendly with Heroku.

cc @lotus/core-team 