### PR TITLE
Fix ghostly failing for middleware session test

### DIFF
--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -86,8 +86,8 @@ describe Lotus::Middleware do
       end
 
       it 'prepends sessions' do
-        sessions_position   = middleware.stack.index ["Rack::Session::Cookie", [{:domain=>nil, :secure=>false}], nil]
-        middleware_position = middleware.stack.index [MockMiddlewareClass, [], nil]
+        sessions_position   = middleware.stack.index(["Rack::Session::Cookie", [{:domain=>nil, :secure=>false}], nil]).to_i
+        middleware_position = middleware.stack.index([MockMiddlewareClass, [], nil])
 
         assert sessions_position < middleware_position,
           "Expected sessions middleware to be prepended"


### PR DESCRIPTION
I often see that one test in middleware_test file ghostly failed with this error ([for example](https://travis-ci.org/lotus/lotus/jobs/99671905#L233)):
```
  1) Error:
Lotus::Middleware::when it's configured with sessions::with other middleware#test_0001_prepends sessions:
NoMethodError: undefined method `<' for nil:NilClass
    /home/travis/build/lotus/lotus/test/middleware_test.rb:92:in `block (4 levels) in <top (required)>'
```
I hope that this change will fix this ghostly bug.

What do you think?