### PR TITLE
Explicit control on assets sources for each application.

### DIFF
--- a/lib/lotus/generators/app/application.rb.tt
+++ b/lib/lotus/generators/app/application.rb.tt
@@ -119,13 +119,12 @@ module <%= config[:classified_app_name] %>
       #
 
       # Specify sources for assets
-      # The directory `<%= config[:app_base_path] %>/assets` is added by default
       #
-      # assets do
-      #   sources << [
-      #     'vendor/assets'
-      #   ]
-      # end
+      assets do
+        sources << [
+          'assets'
+        ]
+      end
 
       ##
       # SECURITY

--- a/lib/lotus/generators/application/app/config/application.rb.tt
+++ b/lib/lotus/generators/application/app/config/application.rb.tt
@@ -116,13 +116,12 @@ module <%= config[:classified_app_name] %>
       #
 
       # Specify sources for assets
-      # The directory `app/assets` is added by default
       #
-      # assets do
-      #   sources << [
-      #     'vendor/assets'
-      #   ]
-      # end
+      assets do
+        sources << [
+          'app/assets'
+        ]
+      end
 
       ##
       # SECURITY

--- a/lib/lotus/loader.rb
+++ b/lib/lotus/loader.rb
@@ -100,7 +100,6 @@ module Lotus
     end
 
     def _configure_assets_framework!
-      source = Lotus.environment.container? ? 'assets' : ['app', 'assets']
       config = configuration
 
       unless application_module.const_defined?('Assets')
@@ -113,7 +112,6 @@ module Lotus
 
           public_directory Lotus.public_directory
           prefix           Utils::PathPrefix.new('/assets').join(config.path_prefix)
-          sources      <<  config.root.join(*source)
 
           manifest         Lotus.public_directory.join('assets.json')
           compile          true

--- a/test/fixtures/cdn/cdn/apps/web/application.rb
+++ b/test/fixtures/cdn/cdn/apps/web/application.rb
@@ -119,13 +119,12 @@ module Web
       #
 
       # Specify sources for assets
-      # The directory `apps/web/assets` is added by default
       #
-      # assets do
-      #   sources << [
-      #     'vendor/assets'
-      #   ]
-      # end
+      assets do
+        sources << [
+          'assets'
+        ]
+      end
 
       ##
       # SECURITY

--- a/test/fixtures/cdn/cdn_app/config/application.rb
+++ b/test/fixtures/cdn/cdn_app/config/application.rb
@@ -116,13 +116,12 @@ module CdnApp
       #
 
       # Specify sources for assets
-      # The directory `app/assets` is added by default
       #
-      # assets do
-      #   sources << [
-      #     'vendor/assets'
-      #   ]
-      # end
+      assets do
+        sources << [
+          'app/assets'
+        ]
+      end
 
       ##
       # SECURITY

--- a/test/fixtures/commands/application/new_app/config/application.rb
+++ b/test/fixtures/commands/application/new_app/config/application.rb
@@ -116,13 +116,12 @@ module NewApp
       #
 
       # Specify sources for assets
-      # The directory `app/assets` is added by default
       #
-      # assets do
-      #   sources << [
-      #     'vendor/assets'
-      #   ]
-      # end
+      assets do
+        sources << [
+          'app/assets'
+        ]
+      end
 
       ##
       # SECURITY

--- a/test/fixtures/commands/generate/app/application.rb
+++ b/test/fixtures/commands/generate/app/application.rb
@@ -119,13 +119,12 @@ module Admin
       #
 
       # Specify sources for assets
-      # The directory `apps/admin/assets` is added by default
       #
-      # assets do
-      #   sources << [
-      #     'vendor/assets'
-      #   ]
-      # end
+      assets do
+        sources << [
+          'assets'
+        ]
+      end
 
       ##
       # SECURITY

--- a/test/fixtures/rake/rake_tasks/apps/web/application.rb
+++ b/test/fixtures/rake/rake_tasks/apps/web/application.rb
@@ -119,13 +119,12 @@ module Web
       #
 
       # Specify sources for assets
-      # The directory `apps/web/assets` is added by default
       #
-      # assets do
-      #   sources << [
-      #     'vendor/assets'
-      #   ]
-      # end
+      assets do
+        sources << [
+          'assets'
+        ]
+      end
 
       ##
       # SECURITY

--- a/test/fixtures/rake/rake_tasks_app/config/application.rb
+++ b/test/fixtures/rake/rake_tasks_app/config/application.rb
@@ -116,13 +116,12 @@ module RakeTasksApp
       #
 
       # Specify sources for assets
-      # The directory `app/assets` is added by default
       #
-      # assets do
-      #   sources << [
-      #     'vendor/assets'
-      #   ]
-      # end
+      assets do
+        sources << [
+          'app/assets'
+        ]
+      end
 
       ##
       # SECURITY

--- a/test/fixtures/static_assets/apps/admin/application.rb
+++ b/test/fixtures/static_assets/apps/admin/application.rb
@@ -118,13 +118,12 @@ module Admin
       #
 
       # Specify sources for assets
-      # The directory `apps/admin/assets` is added by default
       #
-      # assets do
-      #   sources << [
-      #     'vendor/assets'
-      #   ]
-      # end
+      assets do
+        sources << [
+          'assets'
+        ]
+      end
 
       ##
       # SECURITY

--- a/test/fixtures/static_assets/apps/web/application.rb
+++ b/test/fixtures/static_assets/apps/web/application.rb
@@ -119,13 +119,12 @@ module Web
       #
 
       # Specify sources for assets
-      # The directory `apps/web/assets` is added by default
       #
-      # assets do
-      #   sources << [
-      #     'vendor/assets'
-      #   ]
-      # end
+      assets do
+        sources << [
+          'assets'
+        ]
+      end
 
       ##
       # SECURITY

--- a/test/fixtures/static_assets_app/config/application.rb
+++ b/test/fixtures/static_assets_app/config/application.rb
@@ -115,13 +115,12 @@ module StaticAssetsApp
       #
 
       # Specify sources for assets
-      # The directory `app/assets` is added by default
       #
-      # assets do
-      #   sources << [
-      #     'vendor/assets'
-      #   ]
-      # end
+      assets do
+        sources << [
+          'app/assets'
+        ]
+      end
 
       ##
       # SECURITY


### PR DESCRIPTION
**This PR changes the current implementation in `master`. That means this isn't a breaking change with 0.5, but with `master`. This because assets are going to be introduced soon with 0.6. So it's just a change that developers shouldn't notice unless their using `HEAD` of this repository.**

---

Before this PR, we use to add the **implicit** following assets sources:

  * For Container it was `apps/web/assets`
  * For Application it was `app/assets`

There are two problems with this approach:

  1. It isn't consistent with other settings. For instance, for loading paths, we don't add them implicitly, but we add them to `application.rb`. (See _Example 1_).

  2. This isn't flexible. If an application doesn't have assets (eg. HTTP API app), it's forced to keep around the default directory (eg. `apps/api/assets`) or the `lotus assets precompile` command will fail and so the deploy.

---

This proposal, solves both the problems above:

  1. `Lotus::Loader` doesn't add the implicit source anymore.
  2. New projects are generated with this setting in `application.rb` (see _Example 2_).

**In this way, we have a consistent, and flexible design that doesn't require any manual intervention from developers.**

If an API app doesn't need `apps/api/assets`, they can remove the directory and comment the relative setting in `apps/api/application.rb`.

---

### Example 1

We use to generate new project with explicit load paths:

```ruby
require 'lotus/helpers'
require 'lotus/assets'

module Web
  class Application < Lotus::Application
    configure do
      load_paths << [
        'controllers',
        'views'
      ]

      # ...
    end
  end
end
```

### Example 2

We now generate new projects by adding that default source for assets as an explicit setting:

```ruby
require 'lotus/helpers'
require 'lotus/assets'

module Web
  class Application < Lotus::Application
    configure do
      assets do
        sources << [
          'assets'
        ]
      end

      # ....
    end
  end
end
```