### PR TITLE
Configurable assets compressors

### DIFF
--- a/lib/lotus/commands/assets/precompile.rb
+++ b/lib/lotus/commands/assets/precompile.rb
@@ -18,7 +18,12 @@ module Lotus
 
         def preload_applications
           @environment.require_application_environment
-          Lotus::Application.preload!
+
+          if @environment.container?
+            Lotus::Container.new
+          else
+            Lotus::Application.preload!
+          end
         end
 
         def precompile

--- a/lib/lotus/generators/app/application.rb.tt
+++ b/lib/lotus/generators/app/application.rb.tt
@@ -117,10 +117,36 @@ module <%= config[:classified_app_name] %>
       ##
       # ASSETS
       #
-
-      # Specify sources for assets
-      #
       assets do
+        # JavaScript compressor
+        #
+        # Supported engines:
+        #
+        #   * :builtin
+        #   * :uglifier
+        #   * :yui
+        #   * :closure
+        #
+        # See: http://lotusrb.org/guides/assets/compressors
+        #
+        # In order to skip JavaScript compression comment the following line
+        javascript_compressor :builtin
+
+        # Stylesheet compressor
+        #
+        # Supported engines:
+        #
+        #   * :builtin
+        #   * :yui
+        #   * :sass
+        #
+        # See: http://lotusrb.org/guides/assets/compressors
+        #
+        # In order to skip stylesheet compression comment the following line
+        stylesheet_compressor :builtin
+
+        # Specify sources for assets
+        #
         sources << [
           'assets'
         ]

--- a/lib/lotus/generators/application/app/config/application.rb.tt
+++ b/lib/lotus/generators/application/app/config/application.rb.tt
@@ -114,10 +114,36 @@ module <%= config[:classified_app_name] %>
       ##
       # ASSETS
       #
-
-      # Specify sources for assets
-      #
       assets do
+        # JavaScript compressor
+        #
+        # Supported engines:
+        #
+        #   * :builtin
+        #   * :uglifier
+        #   * :yui
+        #   * :closure
+        #
+        # See: http://lotusrb.org/guides/assets/compressors
+        #
+        # In order to skip JavaScript compression comment the following line
+        javascript_compressor :builtin
+
+        # Stylesheet compressor
+        #
+        # Supported engines:
+        #
+        #   * :builtin
+        #   * :yui
+        #   * :sass
+        #
+        # See: http://lotusrb.org/guides/assets/compressors
+        #
+        # In order to skip stylesheet compression comment the following line
+        stylesheet_compressor :builtin
+
+        # Specify sources for assets
+        #
         sources << [
           'app/assets'
         ]

--- a/test/fixtures/cdn/cdn/apps/web/application.rb
+++ b/test/fixtures/cdn/cdn/apps/web/application.rb
@@ -121,6 +121,9 @@ module Web
       # Specify sources for assets
       #
       assets do
+        javascript_compressor :builtin
+        stylesheet_compressor :builtin
+
         sources << [
           'assets'
         ]

--- a/test/fixtures/cdn/cdn_app/config/application.rb
+++ b/test/fixtures/cdn/cdn_app/config/application.rb
@@ -118,6 +118,9 @@ module CdnApp
       # Specify sources for assets
       #
       assets do
+        javascript_compressor :builtin
+        stylesheet_compressor :builtin
+
         sources << [
           'app/assets'
         ]

--- a/test/fixtures/commands/application/new_app/config/application.rb
+++ b/test/fixtures/commands/application/new_app/config/application.rb
@@ -114,10 +114,36 @@ module NewApp
       ##
       # ASSETS
       #
-
-      # Specify sources for assets
-      #
       assets do
+        # JavaScript compressor
+        #
+        # Supported engines:
+        #
+        #   * :builtin
+        #   * :uglifier
+        #   * :yui
+        #   * :closure
+        #
+        # See: http://lotusrb.org/guides/assets/compressors
+        #
+        # In order to skip JavaScript compression comment the following line
+        javascript_compressor :builtin
+
+        # Stylesheet compressor
+        #
+        # Supported engines:
+        #
+        #   * :builtin
+        #   * :yui
+        #   * :sass
+        #
+        # See: http://lotusrb.org/guides/assets/compressors
+        #
+        # In order to skip stylesheet compression comment the following line
+        stylesheet_compressor :builtin
+
+        # Specify sources for assets
+        #
         sources << [
           'app/assets'
         ]

--- a/test/fixtures/commands/generate/app/application.rb
+++ b/test/fixtures/commands/generate/app/application.rb
@@ -117,10 +117,36 @@ module Admin
       ##
       # ASSETS
       #
-
-      # Specify sources for assets
-      #
       assets do
+        # JavaScript compressor
+        #
+        # Supported engines:
+        #
+        #   * :builtin
+        #   * :uglifier
+        #   * :yui
+        #   * :closure
+        #
+        # See: http://lotusrb.org/guides/assets/compressors
+        #
+        # In order to skip JavaScript compression comment the following line
+        javascript_compressor :builtin
+
+        # Stylesheet compressor
+        #
+        # Supported engines:
+        #
+        #   * :builtin
+        #   * :yui
+        #   * :sass
+        #
+        # See: http://lotusrb.org/guides/assets/compressors
+        #
+        # In order to skip stylesheet compression comment the following line
+        stylesheet_compressor :builtin
+
+        # Specify sources for assets
+        #
         sources << [
           'assets'
         ]

--- a/test/fixtures/rake/rake_tasks/apps/web/application.rb
+++ b/test/fixtures/rake/rake_tasks/apps/web/application.rb
@@ -117,10 +117,36 @@ module Web
       ##
       # ASSETS
       #
-
-      # Specify sources for assets
-      #
       assets do
+        # JavaScript compressor
+        #
+        # Supported engines:
+        #
+        #   * :builtin
+        #   * :uglifier
+        #   * :yui
+        #   * :closure
+        #
+        # See: http://lotusrb.org/guides/assets/compressors
+        #
+        # In order to skip JavaScript compression comment the following line
+        javascript_compressor :builtin
+
+        # Stylesheet compressor
+        #
+        # Supported engines:
+        #
+        #   * :builtin
+        #   * :yui
+        #   * :sass
+        #
+        # See: http://lotusrb.org/guides/assets/compressors
+        #
+        # In order to skip stylesheet compression comment the following line
+        stylesheet_compressor :builtin
+
+        # Specify sources for assets
+        #
         sources << [
           'assets'
         ]

--- a/test/fixtures/rake/rake_tasks_app/config/application.rb
+++ b/test/fixtures/rake/rake_tasks_app/config/application.rb
@@ -114,10 +114,36 @@ module RakeTasksApp
       ##
       # ASSETS
       #
-
-      # Specify sources for assets
-      #
       assets do
+        # JavaScript compressor
+        #
+        # Supported engines:
+        #
+        #   * :builtin
+        #   * :uglifier
+        #   * :yui
+        #   * :closure
+        #
+        # See: http://lotusrb.org/guides/assets/compressors
+        #
+        # In order to skip JavaScript compression comment the following line
+        javascript_compressor :builtin
+
+        # Stylesheet compressor
+        #
+        # Supported engines:
+        #
+        #   * :builtin
+        #   * :yui
+        #   * :sass
+        #
+        # See: http://lotusrb.org/guides/assets/compressors
+        #
+        # In order to skip stylesheet compression comment the following line
+        stylesheet_compressor :builtin
+
+        # Specify sources for assets
+        #
         sources << [
           'app/assets'
         ]

--- a/test/fixtures/static_assets/apps/admin/application.rb
+++ b/test/fixtures/static_assets/apps/admin/application.rb
@@ -120,6 +120,9 @@ module Admin
       # Specify sources for assets
       #
       assets do
+        javascript_compressor :builtin
+        stylesheet_compressor :builtin
+
         sources << [
           'assets'
         ]

--- a/test/fixtures/static_assets/apps/web/application.rb
+++ b/test/fixtures/static_assets/apps/web/application.rb
@@ -121,6 +121,9 @@ module Web
       # Specify sources for assets
       #
       assets do
+        javascript_compressor :builtin
+        stylesheet_compressor :builtin
+
         sources << [
           'assets'
         ]

--- a/test/fixtures/static_assets_app/config/application.rb
+++ b/test/fixtures/static_assets_app/config/application.rb
@@ -117,6 +117,9 @@ module StaticAssetsApp
       # Specify sources for assets
       #
       assets do
+        javascript_compressor :builtin
+        stylesheet_compressor :builtin
+
         sources << [
           'app/assets'
         ]

--- a/test/integration/assets_digest_mode/test_application.rb
+++ b/test/integration/assets_digest_mode/test_application.rb
@@ -41,7 +41,7 @@ describe 'Render assets path with digest mode (Application)' do
     get '/'
 
     body = response.body
-    body.must_include %(<link href="/assets/application-7984a5b323a5e3a95bf8b13b87a5c8c3.css" type="text/css" rel="stylesheet">)
-    body.must_include %(<link href="/assets/home-fc1454db4345366035149b045c3dba00.css" type="text/css" rel="stylesheet">)
+    body.must_include %(<link href="/assets/application-5ebdabab46f08c2cc8d56425bb34bc38.css" type="text/css" rel="stylesheet">)
+    body.must_include %(<link href="/assets/home-c229183232e6cfbf965a21ec0b06ee06.css" type="text/css" rel="stylesheet">)
   end
 end

--- a/test/integration/assets_digest_mode/test_container.rb
+++ b/test/integration/assets_digest_mode/test_container.rb
@@ -41,7 +41,7 @@ describe 'Render assets path with digest mode (Container)' do
     get '/'
 
     body = response.body
-    body.must_include %(<link href="/assets/application-1e7f8e4a4ea8bd7ca5e7e4f37ff9c898.css" type="text/css" rel="stylesheet">)
-    body.must_include %(<link href="/assets/home-fc1454db4345366035149b045c3dba00.css" type="text/css" rel="stylesheet">)
+    body.must_include %(<link href="/assets/application-34a87596e5ba23b89a36e910c15bfb43.css" type="text/css" rel="stylesheet">)
+    body.must_include %(<link href="/assets/home-c229183232e6cfbf965a21ec0b06ee06.css" type="text/css" rel="stylesheet">)
   end
 end

--- a/test/integration/assets_precompile/test_application.rb
+++ b/test/integration/assets_precompile/test_application.rb
@@ -33,9 +33,9 @@ describe 'Precompile static assets (Application)' do
     assets_directory.join('favicon-04115b81b60f4303104a28aba667ab16.ico').must_be :exist?
 
     assets_directory.join('application.css').must_be :exist?
-    assets_directory.join('application-7984a5b323a5e3a95bf8b13b87a5c8c3.css').must_be :exist?
+    assets_directory.join('application-5ebdabab46f08c2cc8d56425bb34bc38.css').must_be :exist?
 
     assets_directory.join('home.css').must_be :exist?
-    assets_directory.join('home-fc1454db4345366035149b045c3dba00.css').must_be :exist?
+    assets_directory.join('home-c229183232e6cfbf965a21ec0b06ee06.css').must_be :exist?
   end
 end

--- a/test/integration/assets_precompile/test_container.rb
+++ b/test/integration/assets_precompile/test_container.rb
@@ -33,9 +33,9 @@ describe 'Precompile static assets (Container)' do
     assets_directory.join('favicon-04115b81b60f4303104a28aba667ab16.ico').must_be :exist?
 
     assets_directory.join('application.css').must_be :exist?
-    assets_directory.join('application-1e7f8e4a4ea8bd7ca5e7e4f37ff9c898.css').must_be :exist?
+    assets_directory.join('application-34a87596e5ba23b89a36e910c15bfb43.css').must_be :exist?
 
     assets_directory.join('home.css').must_be :exist?
-    assets_directory.join('home-fc1454db4345366035149b045c3dba00.css').must_be :exist?
+    assets_directory.join('home-c229183232e6cfbf965a21ec0b06ee06.css').must_be :exist?
   end
 end

--- a/test/integration/cdn/test_application.rb
+++ b/test/integration/cdn/test_application.rb
@@ -29,6 +29,6 @@ describe 'CDN (Application)' do
     body = get("/").body
 
     body.must_include %(<link href="https://cdn.example.org/assets/favicon-4b49a383ea9cf9a46820b3a2374de6fe.ico" rel="shortcut icon" type="image/x-icon">)
-    body.must_include %(<link href="https://cdn.example.org/assets/charge-d0ce88a785ae8734d2d802e5a48888d0.css" type="text/css" rel="stylesheet">)
+    body.must_include %(<link href="https://cdn.example.org/assets/charge-b45434daf18d5b0deb8aeab4220f5b86.css" type="text/css" rel="stylesheet">)
   end
 end

--- a/test/integration/cdn/test_container.rb
+++ b/test/integration/cdn/test_container.rb
@@ -34,6 +34,6 @@ describe 'CDN (Container)' do
     body = get("/").body
 
     body.must_include %(<link href="https://cdn.example.org/assets/favicon-4b49a383ea9cf9a46820b3a2374de6fe.ico" rel="shortcut icon" type="image/x-icon">)
-    body.must_include %(<script src="https://cdn.example.org/assets/analytics-e6b4bf3dc57f3e5481f416f9020c1699.js" type="text/javascript"></script>)
+    body.must_include %(<script src="https://cdn.example.org/assets/analytics-9fd60e0c3af3bb376e3c17f65ac751cd.js" type="text/javascript"></script>)
   end
 end


### PR DESCRIPTION
Generate new projects and applications with the following assets settings:

```ruby
# apps/web/application.rb
module Web
  class Application < Lotus::Application
    configure do
      # ...

      ##
      # ASSETS
      #
      assets do
        # JavaScript compressor
        #
        # Supported engines:
        #
        #   * :builtin
        #   * :uglifier
        #   * :yui
        #   * :closure
        #
        # See: http://lotusrb.org/guides/assets/compressors
        #
        # In order to skip JavaScript compression comment the following line
        javascript_compressor :builtin

        # Stylesheet compressor
        #
        # Supported engines:
        #
        #   * :builtin
        #   * :yui
        #   * :sass
        #
        # See: http://lotusrb.org/guides/assets/compressors
        #
        # In order to skip stylesheet compression comment the following line
        stylesheet_compressor :builtin

        # Specify sources for assets
        #
        sources << [
          'assets'
        ]
      end
    end
  end
end
```

---

The default compressor for both javascripts and stylesheets is `:builtin`. **It's not an efficient compressor, but it's a good starting point, it's pure Ruby, it's fast and it doesn't require any external dependency.**

Developers can choose their own favorite engine and use it.

---

/cc @lotus/core-team 