### PR TITLE
Fix problem with dash char in app name

### DIFF
--- a/lib/lotus/commands/generate/app.rb
+++ b/lib/lotus/commands/generate/app.rb
@@ -96,7 +96,7 @@ module Lotus
         end
 
         def classified_app_name
-          Utils::String.new(app_name).classify
+          Utils::String.new(app_name).classify.tr('::', '')
         end
 
         def assert_application_name!(value)

--- a/lib/lotus/commands/new/app.rb
+++ b/lib/lotus/commands/new/app.rb
@@ -104,7 +104,7 @@ module Lotus
         end
 
         def classified_app_name
-          Utils::String.new(app_name).classify
+          Utils::String.new(app_name).classify.tr('::', '')
         end
 
         # def application_base_path

--- a/test/commands/generate/app_test.rb
+++ b/test/commands/generate/app_test.rb
@@ -45,6 +45,11 @@ describe Lotus::Commands::Generate::App do
       end
     end
 
+    it 'returns valid classified app name' do
+      command = Lotus::Commands::Generate::App.new({ architecture: 'container' }, 'awesome-test-app')
+      command.template_options[:classified_app_name].must_equal 'AwesomeTestApp'
+    end
+
     it 'create files' do
       with_temp_dir do |original_wd|
         setup_container_app(original_wd)

--- a/test/commands/new/app_test.rb
+++ b/test/commands/new/app_test.rb
@@ -43,15 +43,15 @@ describe Lotus::Commands::New::App do
         end
       end
     end
-  end
 
-  describe 'rspec' do
-    it 'creates files' do
-      with_temp_dir do |original_wd|
-        command = Lotus::Commands::New::App.new({'test' => 'rspec'}, 'new_app')
-        capture_io { command.start }
+    describe 'rspec' do
+      it 'creates files' do
+        with_temp_dir do |original_wd|
+          command = Lotus::Commands::New::App.new({'test' => 'rspec'}, 'new_app')
+          capture_io { command.start }
 
-        assert_generated_app('rspec', original_wd)
+          assert_generated_app('rspec', original_wd)
+        end
       end
     end
   end

--- a/test/commands/new/app_test.rb
+++ b/test/commands/new/app_test.rb
@@ -54,6 +54,11 @@ describe Lotus::Commands::New::App do
         end
       end
     end
+
+    it 'returns valid classified app name' do
+      command = Lotus::Commands::New::App.new({}, 'awesome-test-app')
+      command.template_options[:classified_app_name].must_equal 'AwesomeTestApp'
+    end
   end
 
   def assert_generated_app(test_framework, original_wd)


### PR DESCRIPTION
If you create new app with app architecture and name which include dash char (`-`) lotus generator created invalid names for modules. I.e this command:
```
$ lotus new test-app --architecture=app
```

Will create `Test-app` module:
``` ruby
module Test-app
  class Application < Lotus::Application
    # ...
  end
end
```

However the rails solved this problem. When you create `test-app` application rails generator set `TestApp` to all partials.

Therefore this commit change all `-` chars to `_` in `app_name` before calling `classify` method. However this changes increase allocation (because `tr` method call through `method_missing`). But I hope that it's
not critical issue on this part.