### PR TITLE
Revert "Remove app prefix for generated DATABASE_URL"

### DIFF
--- a/lib/lotus/generators/application/app/.env.development.tt
+++ b/lib/lotus/generators/application/app/.env.development.tt
@@ -1,4 +1,4 @@
 # Define ENV variables for development environment
-DATABASE_URL="<%= config[:database_config][:uri][:development] %>"
+<%= config[:upcase_app_name] %>_DATABASE_URL="<%= config[:database_config][:uri][:development] %>"
 <%= config[:upcase_app_name] %>_SESSIONS_SECRET="<%= SecureRandom.hex(32) %>"
 SERVE_STATIC_ASSETS="true"

--- a/lib/lotus/generators/application/app/.env.test.tt
+++ b/lib/lotus/generators/application/app/.env.test.tt
@@ -1,4 +1,4 @@
 # Define ENV variables for test environment
-DATABASE_URL="<%= config[:database_config][:uri][:test] %>"
+<%= config[:app_name].to_env_s %>_DATABASE_URL="<%= config[:database_config][:uri][:test] %>"
 <%= config[:upcase_app_name] %>_SESSIONS_SECRET="<%= SecureRandom.hex(32) %>"
 SERVE_STATIC_ASSETS="true"

--- a/lib/lotus/generators/application/app/lib/app_name.rb.tt
+++ b/lib/lotus/generators/application/app/lib/app_name.rb.tt
@@ -15,7 +15,7 @@ Lotus::Model.configure do
   #    adapter type: :sql, uri: 'postgres://localhost/<%= config[:app_name] %>_development'
   #    adapter type: :sql, uri: 'mysql://localhost/<%= config[:app_name] %>_development'
   #
-  adapter type: :<%= config[:database_config][:type] %>, uri: ENV['DATABASE_URL']
+  adapter type: :<%= config[:database_config][:type] %>, uri: ENV['<%= config[:app_name].to_env_s %>_DATABASE_URL']
 
   <%- if config[:database_config][:type] == :sql -%>
   ##

--- a/lib/lotus/generators/application/container/.env.development.tt
+++ b/lib/lotus/generators/application/container/.env.development.tt
@@ -1,3 +1,3 @@
 # Define ENV variables for development environment
-DATABASE_URL="<%= config[:database_config][:uri][:development] %>"
+<%= config[:app_name].to_env_s %>_DATABASE_URL="<%= config[:database_config][:uri][:development] %>"
 SERVE_STATIC_ASSETS="true"

--- a/lib/lotus/generators/application/container/.env.test.tt
+++ b/lib/lotus/generators/application/container/.env.test.tt
@@ -1,3 +1,3 @@
 # Define ENV variables for test environment
-DATABASE_URL="<%= config[:database_config][:uri][:test] %>"
+<%= config[:app_name].to_env_s %>_DATABASE_URL="<%= config[:database_config][:uri][:test] %>"
 SERVE_STATIC_ASSETS="true"

--- a/lib/lotus/generators/application/container/lib/app_name.rb.tt
+++ b/lib/lotus/generators/application/container/lib/app_name.rb.tt
@@ -16,7 +16,7 @@ Lotus::Model.configure do
   #    adapter type: :sql, uri: 'postgres://localhost/<%= config[:app_name] %>_development'
   #    adapter type: :sql, uri: 'mysql://localhost/<%= config[:app_name] %>_development'
   #
-  adapter type: :<%= config[:database_config][:type] %>, uri: ENV['DATABASE_URL']
+  adapter type: :<%= config[:database_config][:type] %>, uri: ENV['<%= config[:app_name].to_env_s %>_DATABASE_URL']
 
   <%- if config[:database_config][:type] == :sql -%>
   ##

--- a/test/commands/new/app_test.rb
+++ b/test/commands/new/app_test.rb
@@ -63,12 +63,12 @@ describe Lotus::Commands::New::App do
       assert_generated_file(fixture_root.join('.env'), '.env')
 
       assert_file_includes('.env.development',
-                           'DATABASE_URL="file:///db/new_app_development"',
+                           'NEW_APP_DATABASE_URL="file:///db/new_app_development"',
                            'SERVE_STATIC_ASSETS="true"',
                            %r{NEW_APP_SESSIONS_SECRET="[\w]{64}"})
 
       assert_file_includes('.env.test',
-                           'DATABASE_URL="file:///db/new_app_test"',
+                           'NEW_APP_DATABASE_URL="file:///db/new_app_test"',
                            'SERVE_STATIC_ASSETS="true"',
                            %r{NEW_APP_SESSIONS_SECRET="[\w]{64}"})
 

--- a/test/commands/new/container_test.rb
+++ b/test/commands/new/container_test.rb
@@ -49,10 +49,10 @@ describe Lotus::Commands::New::Container do
         capture_io { command.start }
         Dir.chdir('new-container') do
           actual_content = File.read('.env.development')
-          actual_content.must_include 'DATABASE_URL="file:///db/new_container_development"'
+          actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="file:///db/new_container_development"'
 
           actual_content = File.read('.env.test')
-          actual_content.must_include 'DATABASE_URL="file:///db/new_container_test"'
+          actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="file:///db/new_container_test"'
         end
       end
     end
@@ -64,10 +64,10 @@ describe Lotus::Commands::New::Container do
           capture_io { command.start }
           Dir.chdir('.') do
             actual_content = File.read('.env.development')
-            actual_content.must_include 'DATABASE_URL="file:///db/testapp_development"'
+            actual_content.must_include 'TESTAPP_DATABASE_URL="file:///db/testapp_development"'
 
             actual_content = File.read('.env.test')
-            actual_content.must_include 'DATABASE_URL="file:///db/testapp_test"'
+            actual_content.must_include 'TESTAPP_DATABASE_URL="file:///db/testapp_test"'
           end
         end
       end
@@ -84,10 +84,10 @@ describe Lotus::Commands::New::Container do
           fixture_root = original_wd.join('test', 'fixtures', 'commands', 'application', 'new_container')
           Dir.chdir('new_container') do
             actual_content = File.read('.env.development')
-            actual_content.must_include 'DATABASE_URL="memory://localhost/new_container_development"'
+            actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="memory://localhost/new_container_development"'
 
             actual_content = File.read('.env.test')
-            actual_content.must_include 'DATABASE_URL="memory://localhost/new_container_test"'
+            actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="memory://localhost/new_container_test"'
 
             assert_generated_file(fixture_root.join('Gemfile.memory'), 'Gemfile')
             assert_generated_file(fixture_root.join('lib', 'new_container.memory.rb'), 'lib/new_container.rb')
@@ -104,10 +104,10 @@ describe Lotus::Commands::New::Container do
           fixture_root = original_wd.join('test', 'fixtures', 'commands', 'application', 'new_container')
           Dir.chdir('new_container') do
             actual_content = File.read('.env.development')
-            actual_content.must_include 'DATABASE_URL="file:///db/new_container_development"'
+            actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="file:///db/new_container_development"'
 
             actual_content = File.read('.env.test')
-            actual_content.must_include 'DATABASE_URL="file:///db/new_container_test"'
+            actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="file:///db/new_container_test"'
 
             assert_generated_file(fixture_root.join('Gemfile.filesystem'), 'Gemfile')
             assert_generated_file(fixture_root.join('lib', 'new_container.filesystem.rb'), 'lib/new_container.rb')
@@ -124,10 +124,10 @@ describe Lotus::Commands::New::Container do
           fixture_root = original_wd.join('test', 'fixtures', 'commands', 'application', 'new_container')
           Dir.chdir('new_container') do
             actual_content = File.read('.env.development')
-            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }sqlite://db/new_container_development.sqlite\"")
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }sqlite://db/new_container_development.sqlite\"")
 
             actual_content = File.read('.env.test')
-            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }sqlite://db/new_container_test.sqlite\"")
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }sqlite://db/new_container_test.sqlite\"")
 
             assert_generated_file(fixture_root.join("Gemfile.#{ adapter_prefix }sqlite3"), 'Gemfile')
             assert_generated_file(fixture_root.join('lib', 'new_container.sqlite3.rb'), 'lib/new_container.rb')
@@ -144,10 +144,10 @@ describe Lotus::Commands::New::Container do
           fixture_root = original_wd.join('test', 'fixtures', 'commands', 'application', 'new_container')
           Dir.chdir('new_container') do
             actual_content = File.read('.env.development')
-            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_development\"")
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_development\"")
 
             actual_content = File.read('.env.test')
-            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_test\"")
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_test\"")
 
             assert_generated_file(fixture_root.join("Gemfile.#{ adapter_prefix }postgres"), 'Gemfile')
             assert_generated_file(fixture_root.join('lib', 'new_container.postgres.rb'), 'lib/new_container.rb')
@@ -165,10 +165,10 @@ describe Lotus::Commands::New::Container do
           fixture_root = original_wd.join('test', 'fixtures', 'commands', 'application', 'new_container')
           Dir.chdir('new_container') do
             actual_content = File.read('.env.development')
-            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }#{ database }://localhost/new_container_development\"")
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }#{ database }://localhost/new_container_development\"")
 
             actual_content = File.read('.env.test')
-            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }#{ database }://localhost/new_container_test\"")
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }#{ database }://localhost/new_container_test\"")
 
             assert_generated_file(fixture_root.join("Gemfile.#{ adapter_prefix }mysql2"), 'Gemfile')
             assert_generated_file(fixture_root.join('lib', 'new_container.mysql2.rb'), 'lib/new_container.rb')
@@ -185,10 +185,10 @@ describe Lotus::Commands::New::Container do
           fixture_root = original_wd.join('test', 'fixtures', 'commands', 'application', 'new_container')
           Dir.chdir('new_container') do
             actual_content = File.read('.env.development')
-            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_development\"")
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_development\"")
 
             actual_content = File.read('.env.test')
-            actual_content.must_include("DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_test\"")
+            actual_content.must_include("NEW_CONTAINER_DATABASE_URL=\"#{ adapter_prefix }postgres://localhost/new_container_test\"")
 
             assert_generated_file(fixture_root.join("Gemfile.#{ adapter_prefix }postgres"), 'Gemfile')
             assert_generated_file(fixture_root.join('lib', 'new_container.postgres.rb'), 'lib/new_container.rb')
@@ -254,11 +254,11 @@ describe Lotus::Commands::New::Container do
       assert_generated_file(fixture_root.join(".lotusrc.#{ test_framework }"), '.lotusrc')
       assert_generated_file(fixture_root.join('.env'), '.env')
       actual_content = File.read('.env.development')
-      actual_content.must_include 'DATABASE_URL="file:///db/new_container_development"'
+      actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="file:///db/new_container_development"'
       actual_content.must_match(%r{WEB_SESSIONS_SECRET="[\w]{64}"})
 
       actual_content = File.read('.env.test')
-      actual_content.must_include 'DATABASE_URL="file:///db/new_container_test"'
+      actual_content.must_include 'NEW_CONTAINER_DATABASE_URL="file:///db/new_container_test"'
       actual_content.must_match %r{WEB_SESSIONS_SECRET="[\w]{64}"}
 
       assert_generated_file(fixture_root.join("Gemfile.#{ test_framework }"), 'Gemfile')

--- a/test/fixtures/commands/application/new_app/lib/new_app.rb
+++ b/test/fixtures/commands/application/new_app/lib/new_app.rb
@@ -15,7 +15,7 @@ Lotus::Model.configure do
   #    adapter type: :sql, uri: 'postgres://localhost/new_app_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_app_development'
   #
-  adapter type: :file_system, uri: ENV['DATABASE_URL']
+  adapter type: :file_system, uri: ENV['NEW_APP_DATABASE_URL']
 
   ##
   # Database mapping

--- a/test/fixtures/commands/application/new_container/lib/new_container.filesystem.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.filesystem.rb
@@ -16,7 +16,7 @@ Lotus::Model.configure do
   #    adapter type: :sql, uri: 'postgres://localhost/new_container_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_container_development'
   #
-  adapter type: :file_system, uri: ENV['DATABASE_URL']
+  adapter type: :file_system, uri: ENV['NEW_CONTAINER_DATABASE_URL']
 
   ##
   # Database mapping

--- a/test/fixtures/commands/application/new_container/lib/new_container.memory.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.memory.rb
@@ -16,7 +16,7 @@ Lotus::Model.configure do
   #    adapter type: :sql, uri: 'postgres://localhost/new_container_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_container_development'
   #
-  adapter type: :memory, uri: ENV['DATABASE_URL']
+  adapter type: :memory, uri: ENV['NEW_CONTAINER_DATABASE_URL']
 
   ##
   # Database mapping

--- a/test/fixtures/commands/application/new_container/lib/new_container.mysql2.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.mysql2.rb
@@ -16,7 +16,7 @@ Lotus::Model.configure do
   #    adapter type: :sql, uri: 'postgres://localhost/new_container_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_container_development'
   #
-  adapter type: :sql, uri: ENV['DATABASE_URL']
+  adapter type: :sql, uri: ENV['NEW_CONTAINER_DATABASE_URL']
 
   ##
   # Migrations

--- a/test/fixtures/commands/application/new_container/lib/new_container.postgres.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.postgres.rb
@@ -16,7 +16,7 @@ Lotus::Model.configure do
   #    adapter type: :sql, uri: 'postgres://localhost/new_container_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_container_development'
   #
-  adapter type: :sql, uri: ENV['DATABASE_URL']
+  adapter type: :sql, uri: ENV['NEW_CONTAINER_DATABASE_URL']
 
   ##
   # Migrations

--- a/test/fixtures/commands/application/new_container/lib/new_container.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.rb
@@ -16,7 +16,7 @@ Lotus::Model.configure do
   #    adapter type: :sql, uri: 'postgres://localhost/new_container_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_container_development'
   #
-  adapter type: :file_system, uri: ENV['DATABASE_URL']
+  adapter type: :file_system, uri: ENV['NEW_CONTAINER_DATABASE_URL']
 
   ##
   # Database mapping

--- a/test/fixtures/commands/application/new_container/lib/new_container.sqlite3.rb
+++ b/test/fixtures/commands/application/new_container/lib/new_container.sqlite3.rb
@@ -16,7 +16,7 @@ Lotus::Model.configure do
   #    adapter type: :sql, uri: 'postgres://localhost/new_container_development'
   #    adapter type: :sql, uri: 'mysql://localhost/new_container_development'
   #
-  adapter type: :sql, uri: ENV['DATABASE_URL']
+  adapter type: :sql, uri: ENV['NEW_CONTAINER_DATABASE_URL']
 
   ##
   # Migrations

--- a/test/integration/cli/database_test.rb
+++ b/test/integration/cli/database_test.rb
@@ -28,19 +28,19 @@ describe 'lotus db' do
 
     File.open(root.join('.env.development'), 'w') do |f|
       f.write <<-DOTENV
-DATABASE_URL="#{ adapter_prefix }sqlite://#{ root.join("db/#{ app_name }_development.sqlite3") }"
+#{ app_name.upcase }_DATABASE_URL="#{ adapter_prefix }sqlite://#{ root.join("db/#{ app_name }_development.sqlite3") }"
       DOTENV
     end
 
     File.open(root.join('.env.test'), 'w') do |f|
       f.write <<-DOTENV
-DATABASE_URL="#{ adapter_prefix }sqlite://#{ root.join("db/#{ app_name }_test.sqlite3") }"
+#{ app_name.upcase }_DATABASE_URL="#{ adapter_prefix }sqlite://#{ root.join("db/#{ app_name }_test.sqlite3") }"
       DOTENV
     end
 
     File.open(root.join('.env'), 'w') do |f|
       f.write <<-DOTENV
-DATABASE_URL="#{ adapter_prefix }sqlite://#{ root.join("db/#{ app_name }.sqlite3") }"
+#{ app_name.upcase }_DATABASE_URL="#{ adapter_prefix }sqlite://#{ root.join("db/#{ app_name }.sqlite3") }"
       DOTENV
     end
 


### PR DESCRIPTION
Reverts lotus/lotus#435

---

This is a breaking change that should stay away from master until we have released a patch release for the other small fixes. See https://github.com/lotus/lotus/milestones/v0.6.1