### PR TITLE
Remove default console engine from cli.rb

### DIFF
--- a/lib/lotus/cli.rb
+++ b/lib/lotus/cli.rb
@@ -51,7 +51,7 @@ module Lotus
     $ > lotus console --engine=pry
     EOS
     method_option :environment, desc: 'path to environment configuration (config/environment.rb)'
-    method_option :engine, desc: "choose a specific console engine: (#{Lotus::Commands::Console::ENGINES.keys.join('/')})", default: Lotus::Commands::Console::DEFAULT_ENGINE
+    method_option :engine, desc: "choose a specific console engine: (#{Lotus::Commands::Console::ENGINES.keys.join('/')})"
     method_option :help, desc: 'displays the usage method'
     def console
       if options[:help]


### PR DESCRIPTION
If default console engine is specified for Thor, then 'engine_lookup' in console.rb never gets to work: `load_engine options.fetch(:engine) { engine_lookup }`. As a result it's not enough to just bundle 'pry' but also have to specify it with --engine=pry.